### PR TITLE
fix(bot-211): upgrade EE builder to aos-sdk 6.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ parts/
 sdist/
 var/
 wheels/
+!build/wheels/
 share/python-wheels/
 *.egg-info/
 .installed.cfg

--- a/build/ee-builder.yml
+++ b/build/ee-builder.yml
@@ -8,7 +8,7 @@ images:
 additional_build_files:
   - src: collections/juniper-apstra.tar.gz
     dest: collections/
-  - src: wheels/aos_sdk-0.1.0-py3-none-any.whl
+  - src: wheels/aos_sdk-6.1.0-py3-none-any.whl
     dest: aos-sdk/
 
 dependencies:
@@ -41,9 +41,11 @@ additional_build_steps:
     - RUN subscription-manager repos --enable=rhocp-4.17-for-rhel-8-`uname -m`-rpms
   prepend_builder:
     # Copy whl file to the path pip expects based on apstra collection requirements.txt
-    - COPY _build/aos-sdk/aos_sdk-0.1.0-py3-none-any.whl /tmp/src/build/wheels/aos_sdk-0.1.0-py3-none-any.whl
+    - COPY _build/aos-sdk/aos_sdk-6.1.0-py3-none-any.whl /tmp/src/build/wheels/aos_sdk-6.1.0-py3-none-any.whl
+    - RUN python3 -m pip install /tmp/src/build/wheels/aos_sdk-6.1.0-py3-none-any.whl
   prepend_final:
-    - COPY _build/aos-sdk/aos_sdk-0.1.0-py3-none-any.whl /runner/build/wheels/aos_sdk-0.1.0-py3-none-any.whl
+    - COPY _build/aos-sdk/aos_sdk-6.1.0-py3-none-any.whl /runner/build/wheels/aos_sdk-6.1.0-py3-none-any.whl
+    - RUN python3 -m pip install /runner/build/wheels/aos_sdk-6.1.0-py3-none-any.whl
   append_final:
     # Python requirements may be installed into /usr/local/lib
     - RUN echo "import sys" >> /usr/lib/python3.11/site-packages/sitecustomize.py

--- a/build/wheels/README.md
+++ b/build/wheels/README.md
@@ -1,0 +1,37 @@
+# build/wheels/
+
+This directory holds the **Apstra SDK wheel file** required to build the Execution Environment image.
+
+> **The wheel is NOT included in this repository.** You must download it from the Juniper Support portal before running `make pipenv` or `make image`.
+
+## Download the Apstra SDK
+
+1. Go to: **https://support.juniper.net/support/downloads/?p=apstra**
+2. Under **"Application Tools"** select **"Apstra Automation Python3 SDK"**.
+3. Download the `.tar.gz` archive (e.g. `apstra-automation-python3-sdk-6.1.0.tar.gz`).
+4. Extract and place the wheel here:
+
+   ```bash
+   tar -xzf apstra-automation-python3-sdk-6.1.0.tar.gz
+   cp path/to/aos_sdk-6.1.0-py3-none-any.whl build/wheels/
+   ```
+
+5. Then run:
+
+   ```bash
+   make pipenv
+   make image
+   ```
+
+> **Important:** Run `make pipenv` only **after** placing the wheel here.
+> If the wheel is absent, `make pipenv` falls back to downloading `aos_sdk-0.1.0`
+> (Apstra 5.1 SDK), which is **not compatible** with Apstra 6.0 / 6.1.
+
+## Compatibility
+
+| Wheel file                         | Apstra Server |
+|------------------------------------|---------------|
+| `aos_sdk-6.1.0-py3-none-any.whl`  | 6.0 / 6.1     |
+| `aos_sdk-0.1.0-py3-none-any.whl`  | 5.1.x         |
+
+Wheel files (`*.whl`) are gitignored — they will never be committed to this repository.


### PR DESCRIPTION
- build/ee-builder.yml: switch SDK wheel from aos_sdk-0.1.0 to aos_sdk-6.1.0
- build/ee-builder.yml: use 'python3 -m pip install' (bare pip not on PATH in RH ee-minimal-rhel8 base image)
- build/wheels/README.md: document that SDK wheel is NOT in repo and must be downloaded from Juniper Support Downloads before running make pipenv/image
- .gitignore: un-ignore build/wheels/ directory so README.md is tracked while *.whl files remain excluded via build/.gitignore