### PR TITLE
Ansible module for IBA Probes 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,8 @@ install: build
 	test-system_agents \
 	test-interface_map \
 	test-fabric_settings \
-	test-ztp_device
+	test-ztp_device \
+	test-iba_probes
 
 # Ignore warnings about localhost from ansible-playbook
 export ANSIBLE_LOCALHOST_WARNING=False
@@ -219,6 +220,9 @@ test-rollback: install
 test-ztp_device: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/ztp_device.yml
 
+test-iba_probes: install
+	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/iba_probes.yml
+
 test-name_resolution: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/name_resolution.yml
 
@@ -293,7 +297,7 @@ delete-connectorops-blueprint: install
 		-e @$(APSTRA_COLLECTION_ROOT)/tests/vars/connectorops_blueprint.yml \
 		-e testbed_file=$(TESTBED_FILE)
 
-test: test-apstra_facts test-blueprint test-virtual_network test-routing_policy test-security_zone test-endpoint_policy test-tag test-resource_group test-configlets test-property_set test-resource_pools test-external_gateway test-connectivity_template test-generic_systems test-system_agents test-interface_map test-fabric_settings test-ztp_device
+test: test-apstra_facts test-blueprint test-virtual_network test-routing_policy test-security_zone test-endpoint_policy test-tag test-resource_group test-configlets test-property_set test-resource_pools test-external_gateway test-connectivity_template test-generic_systems test-system_agents test-interface_map test-fabric_settings test-ztp_device test-iba_probes
 
 # Integration Tests
 .PHONY: test-integration-property_set

--- a/ansible_collections/juniper/apstra/docs/iba_probes_module.rst
+++ b/ansible_collections/juniper/apstra/docs/iba_probes_module.rst
@@ -1,0 +1,537 @@
+.. Document meta
+
+:orphan:
+
+.. Title
+
+juniper.apstra.iba_probes module -- Manage IBA probes and dashboards in Apstra
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This module is part of the `juniper.apstra collection <https://galaxy.ansible.com/ui/repo/published/juniper/apstra/>`_.
+
+.. version_added
+
+.. rst-class:: ansible-version-added
+
+New in juniper.apstra 0.1.0
+
+.. contents::
+   :local:
+   :depth: 1
+
+Synopsis
+--------
+
+- This module manages IBA (Intent-Based Analytics) probes and dashboards in Apstra blueprints.
+- Supports instantiation of predefined (built-in) probes from a catalog of 48+ probe types.
+- Supports CRUD operations on custom (raw) probes with user-defined processors and stages.
+- Supports CRUD operations on IBA dashboards for probe visualisation.
+- Probes and dashboards can be referenced by UUID or label for all operations (create, read, update, delete).
+- The module uses the Apstra REST API directly via ``raw_request`` as the SDK does not expose a dedicated IBA probe interface.
+
+Overview
+--------
+
+**Intent-Based Analytics (IBA)** is Apstra's real-time analytics framework that continuously monitors your data centre fabric and raises anomalies when the network deviates from its intended state. At the heart of IBA are **probes** — self-contained analytics pipelines that:
+
+1. **Collect** telemetry from every managed device (counters, BGP state, LLDP, EVPN, etc.).
+2. **Process** data through a chain of processors (aggregation, range checks, comparisons, match counts).
+3. **Produce stages** — intermediate and final result tables that feed dashboards and anomaly detection.
+4. **Raise anomalies** when values fall outside expected ranges.
+
+Key Concepts
+~~~~~~~~~~~~
+
+- **Predefined Probe**: A built-in probe template shipped with Apstra. You instantiate it with parameters (label, thresholds, durations). Apstra auto-generates the full processor pipeline.
+- **Custom Probe**: A probe you build from scratch, defining every processor, input, output, and graph query.
+- **Dashboard**: A visual grouping of probe stages in the Apstra UI for at-a-glance monitoring.
+- **Anomaly**: A deviation from expected state raised by a probe.
+
+Parameters
+----------
+
+**api_url** (string): The URL used to access the Apstra api. Default: ``APSTRA_API_URL`` environment variable.
+
+**verify_certificates** (boolean): If set to false, SSL certificates will not be verified. Default: ``True``.
+
+**username** (string): The username for authentication. Default: ``APSTRA_USERNAME`` environment variable.
+
+**password** (string): The password for authentication. Default: ``APSTRA_PASSWORD`` environment variable.
+
+**auth_token** (string): The authentication token to use if already authenticated. Default: ``APSTRA_AUTH_TOKEN`` environment variable.
+
+**type** (string): The type of IBA resource to manage. Choices: ``predefined``, ``probe``, ``dashboard``. Default: ``predefined``.
+
+  - ``predefined`` — Instantiates a probe from the Apstra predefined probe catalog (48+ types).
+  - ``probe`` — Manages custom (raw) probes directly.
+  - ``dashboard`` — Manages IBA dashboards.
+
+**id** (dictionary): Dictionary containing resource identifiers.
+
+  - Always requires ``blueprint`` key with the blueprint UUID or label.
+  - For existing probes, include ``probe`` key with probe UUID or label.
+  - For dashboards, include ``dashboard`` key with dashboard UUID or label.
+  - Name/label resolution is supported for ``blueprint``, ``probe``, and ``dashboard`` keys.
+
+**body** (dictionary): Dictionary containing the resource details.
+
+  - For predefined probes: ``predefined_probe`` is the probe name (e.g. ``bgp_session``), and additional keys are the schema parameters (``label``, ``duration``, ``threshold``, etc.).
+  - For custom probes: keys include ``label``, ``description``, ``disabled``, and ``processors``.
+  - For dashboards: keys include ``label`` and ``description``.
+
+**state** (string): Desired state of the resource. Choices: ``present``, ``absent``. Default: ``present``.
+
+Return Values
+-------------
+
+**changed** (boolean): Indicates whether the module has made any changes. Returned: always.
+
+**id** (dictionary): Dictionary of resource identifiers (``blueprint``, ``probe`` or ``dashboard``). Returned: on create or when found by label.
+
+**probe** (dictionary): The full probe object details. Returned: when type is ``predefined`` or ``probe`` with state ``present``.
+
+**dashboard** (dictionary): The full dashboard object details. Returned: when type is ``dashboard`` with state ``present``.
+
+**changes** (dictionary): Dictionary of updates that were applied. Returned: on update.
+
+**msg** (string): The output message that the module generates. Returned: always.
+
+**predefined_probes** (list): List of available predefined probe names. Returned: when type is ``predefined`` with state ``present`` and no ``body`` specified.
+
+Available Predefined Probes (48 Types)
+--------------------------------------
+
+Traffic & Bandwidth
+~~~~~~~~~~~~~~~~~~~
+
+- ``traffic`` — Monitors interface traffic counters (RX/TX utilization, errors, broadcasts).
+- ``bandwidth_utilization`` — Calculates bandwidth utilization history at varying aggregation levels.
+- ``eastwest_traffic`` — Tracks east-west traffic patterns across the fabric.
+- ``stripe_traffic`` — Monitors traffic distribution across fabric stripes.
+
+BGP & Routing
+~~~~~~~~~~~~~
+
+- ``bgp_session`` — Monitors BGP session status; raises anomalies for flapping sessions.
+- ``external_routes`` — Tracks external routes received by the fabric.
+- ``evpn_vxlan_type3`` — Validates EVPN VXLAN Type-3 routes.
+- ``evpn_vxlan_type5`` — Validates EVPN VXLAN Type-5 routes.
+
+Load Balancing & ECMP
+~~~~~~~~~~~~~~~~~~~~~
+
+- ``fabric_ecmp_imbalance`` — Detects ECMP imbalance across fabric interfaces.
+- ``external_ecmp_imbalance`` — Detects ECMP imbalance on external links.
+- ``spine_superspine_ecmp_imbalance`` — ECMP imbalance between spine and superspine layers.
+- ``lag_imbalance`` — Detects traffic imbalance across LAG member interfaces.
+- ``mlag_imbalance`` — Detects traffic imbalance across MLAG pairs.
+- ``esi_imbalance`` — Detects traffic imbalance across ESI-LAG member interfaces.
+
+Device Health & Telemetry
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``device_health`` — Alerts when CPU, memory, or disk usage exceeds thresholds.
+- ``device_telemetry_health`` — Monitors telemetry streaming health.
+- ``environmental_data`` — Monitors temperature, fan speed, and power supply status.
+- ``npu_utilization`` — Monitors NPU (Network Processing Unit) utilization.
+- ``pfe_usage`` — Monitors Packet Forwarding Engine memory and filter utilisation.
+
+Interface & Fabric Monitoring
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+- ``fabric_interface_flapping`` — Detects interface flapping on fabric links.
+- ``specific_interface_flapping`` — Monitors flapping on specific named interfaces.
+- ``spine_superspine_interface_flapping`` — Interface flapping on spine-superspine links.
+- ``fabric_hotcold_ifcounter`` — Identifies hot/cold fabric interfaces by counter values.
+- ``specific_hotcold_ifcounter`` — Hot/cold analysis on specific interfaces.
+- ``spine_superspine_hotcold_ifcounter`` — Hot/cold counters on spine-superspine interfaces.
+- ``optical_transceivers`` — Monitors optical transceiver power levels.
+- ``packet_discard_percentage`` — Tracks packet discard rates across interfaces.
+
+Security & Policy
+~~~~~~~~~~~~~~~~~
+
+- ``copp`` — Validates Control Plane Policing output; alerts on excessive policer drops.
+- ``interface_policy_dot1x`` — Monitors 802.1X interface policy compliance.
+
+Fault Tolerance
+~~~~~~~~~~~~~~~
+
+- ``spine_fault_tolerance`` — Validates that the fabric can tolerate spine failures.
+- ``lag_fault_tolerance`` — Validates LAG fault tolerance across member links.
+
+EVPN & VXLAN
+~~~~~~~~~~~~~
+
+- ``evpn_host_flapping`` — Detects hosts flapping between EVPN endpoints.
+- ``vxlan_floodlist`` — Validates VXLAN flood list consistency.
+- ``shared_tunnel_mode`` — Monitors shared tunnel mode operation.
+
+MAC & ARP
+~~~~~~~~~
+
+- ``mac_monitor`` — Monitors MAC address table entries.
+
+Server & Compute
+~~~~~~~~~~~~~~~~
+
+- ``server_sla_a`` — Server SLA monitoring (type A).
+- ``server_sla_b`` — Server SLA monitoring (type B).
+- ``compute_agent_hw_counters`` — Analyses hardware counters from compute agents.
+- ``multiagent_detector`` — Detects multiple telemetry agents on a single device.
+
+Virtual Infrastructure
+~~~~~~~~~~~~~~~~~~~~~~
+
+- ``hypervisor_mtu_checks`` — Validates MTU settings across hypervisor environments.
+- ``hypervisor_mtu_mismatch`` — Detects MTU mismatches between hypervisors.
+- ``missing_vlan_vms`` — Identifies VMs with missing VLAN configurations.
+- ``virtual_infra_hypervisor_redundancy_checks`` — Validates hypervisor network redundancy.
+- ``virtual_infra_lag_match`` — Checks LAG configuration consistency for virtual infrastructure.
+- ``virtual_infra_missing_lldp`` — Detects missing LLDP on virtual infrastructure ports.
+- ``virtual_infra_vlan_match`` — Validates VLAN configuration matching for virtual infrastructure.
+
+Drain Operations
+~~~~~~~~~~~~~~~~
+
+- ``drain_node_traffic_anomaly`` — Monitors traffic during node drain operations.
+
+Examples
+--------
+
+Predefined Probes
+~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml+jinja
+
+    - name: Authenticate to Apstra
+      juniper.apstra.authenticate:
+        logout: false
+      register: auth
+
+    - name: List all available predefined probes
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: predefined_list
+
+    - name: Create a BGP Session probe
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        body:
+          predefined_probe: bgp_session
+          label: "BGP Monitoring"
+          duration: 300
+          threshold: 40
+        auth_token: "{{ auth.token }}"
+      register: bgp_probe
+
+    - name: Create a Bandwidth Utilization probe
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        body:
+          predefined_probe: bandwidth_utilization
+          label: "Bandwidth Utilization"
+          first_summary_average_period: 120
+          first_summary_total_duration: 3600
+          second_summary_average_period: 3600
+          second_summary_total_duration: 2592000
+        auth_token: "{{ auth.token }}"
+
+    - name: Create a Device System Health probe
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        body:
+          predefined_probe: device_health
+          label: "Device System Health"
+          raise_switch_anomaly: true
+          raise_server_anomaly: true
+          history_duration: 2592000
+        auth_token: "{{ auth.token }}"
+
+    - name: Create a Control Plane Policing probe
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        body:
+          predefined_probe: copp
+          label: "Control Plane Policing"
+          aggregation_period: 300
+          collection_interval: 120
+          history_duration: 2592000
+          drop_count_threshold: 1
+        auth_token: "{{ auth.token }}"
+
+    - name: Create a Device Telemetry Health probe
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        body:
+          predefined_probe: device_telemetry_health
+          label: "Device Telemetry Health"
+        auth_token: "{{ auth.token }}"
+
+    - name: Create a LAG Imbalance probe
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        body:
+          predefined_probe: lag_imbalance
+          label: "LAG Imbalance"
+        auth_token: "{{ auth.token }}"
+
+    - name: Create a Fabric ECMP Imbalance probe
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        body:
+          predefined_probe: fabric_ecmp_imbalance
+          label: "ECMP Imbalance (Fabric)"
+        auth_token: "{{ auth.token }}"
+
+    - name: Create an ESI Imbalance probe
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        body:
+          predefined_probe: esi_imbalance
+          label: "ESI Imbalance"
+        auth_token: "{{ auth.token }}"
+
+    - name: Create a MAC Monitor probe
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "my-blueprint"
+        body:
+          predefined_probe: mac_monitor
+          label: "MAC Monitor"
+        auth_token: "{{ auth.token }}"
+
+Read & Update Probes
+~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml+jinja
+
+    - name: Read a probe by ID
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "my-blueprint"
+          probe: "{{ bgp_probe.id.probe }}"
+        state: present
+        auth_token: "{{ auth.token }}"
+
+    - name: Read a probe by label (name resolution)
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "my-blueprint"
+          probe: "BGP Monitoring"
+        state: present
+        auth_token: "{{ auth.token }}"
+
+    - name: Update a probe description (find by label in body)
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "my-blueprint"
+        body:
+          label: "BGP Monitoring"
+          description: "Updated BGP probe description"
+        state: present
+        auth_token: "{{ auth.token }}"
+
+    - name: Disable a probe
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "my-blueprint"
+        body:
+          label: "BGP Monitoring"
+          disabled: true
+        state: present
+        auth_token: "{{ auth.token }}"
+
+Delete Probes
+~~~~~~~~~~~~~
+
+.. code-block:: yaml+jinja
+
+    - name: Delete a probe by ID
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "my-blueprint"
+          probe: "{{ bgp_probe.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: Delete a probe by label (via id.probe name resolution)
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "my-blueprint"
+          probe: "BGP Monitoring"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: Delete a probe by label (via body.label fallback)
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "my-blueprint"
+        body:
+          label: "BGP Monitoring"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+IBA Dashboards
+~~~~~~~~~~~~~~
+
+.. code-block:: yaml+jinja
+
+    - name: Create an IBA dashboard
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "my-blueprint"
+        body:
+          label: "Fabric Health Dashboard"
+          description: "Overview of fabric health probes"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: dash
+
+    - name: Read a dashboard by label (name resolution)
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "my-blueprint"
+          dashboard: "Fabric Health Dashboard"
+        state: present
+        auth_token: "{{ auth.token }}"
+
+    - name: Update a dashboard description
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "my-blueprint"
+        body:
+          label: "Fabric Health Dashboard"
+          description: "Updated description"
+        state: present
+        auth_token: "{{ auth.token }}"
+
+    - name: Delete a dashboard by ID
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "my-blueprint"
+          dashboard: "{{ dash.id.dashboard }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: Delete a dashboard by label (name resolution)
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "my-blueprint"
+          dashboard: "Fabric Health Dashboard"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+Name / Label Resolution
+~~~~~~~~~~~~~~~~~~~~~~~
+
+All ID fields (``blueprint``, ``probe``, ``dashboard``) support name/label resolution.
+You can pass either a UUID or a human-readable label, and the module resolves it automatically.
+
+.. code-block:: yaml+jinja
+
+    # Using UUIDs
+    - name: Read probe by UUID
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "54bd9839-275e-4444-8ef2-5093f49e08b7"
+          probe: "99a47423-c172-4006-b55a-da37102f73e4"
+        state: present
+        auth_token: "{{ auth.token }}"
+
+    # Using labels (equivalent to above)
+    - name: Read probe by label
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "my-blueprint-label"
+          probe: "BGP Monitoring"
+        state: present
+        auth_token: "{{ auth.token }}"
+
+API Endpoints
+-------------
+
+The module uses these Apstra REST API endpoints:
+
+.. list-table::
+  :width: 100%
+  :widths: 10 50 40
+  :header-rows: 1
+
+  * - Method
+    - Endpoint
+    - Description
+  * - ``GET``
+    - ``/api/blueprints/{bp_id}/probes``
+    - List all probes
+  * - ``POST``
+    - ``/api/blueprints/{bp_id}/probes``
+    - Create a custom probe
+  * - ``GET``
+    - ``/api/blueprints/{bp_id}/probes/{probe_id}``
+    - Get a probe
+  * - ``PUT``
+    - ``/api/blueprints/{bp_id}/probes/{probe_id}``
+    - Update a probe
+  * - ``DELETE``
+    - ``/api/blueprints/{bp_id}/probes/{probe_id}``
+    - Delete a probe
+  * - ``GET``
+    - ``/api/blueprints/{bp_id}/iba/predefined-probes``
+    - List predefined probes
+  * - ``POST``
+    - ``/api/blueprints/{bp_id}/iba/predefined-probes/{name}``
+    - Instantiate predefined probe
+  * - ``GET``
+    - ``/api/blueprints/{bp_id}/iba/dashboards``
+    - List dashboards
+  * - ``POST``
+    - ``/api/blueprints/{bp_id}/iba/dashboards``
+    - Create a dashboard
+  * - ``GET``
+    - ``/api/blueprints/{bp_id}/iba/dashboards/{id}``
+    - Get a dashboard
+  * - ``PUT``
+    - ``/api/blueprints/{bp_id}/iba/dashboards/{id}``
+    - Update a dashboard
+  * - ``DELETE``
+    - ``/api/blueprints/{bp_id}/iba/dashboards/{id}``
+    - Delete a dashboard

--- a/ansible_collections/juniper/apstra/docs/index.rst
+++ b/ansible_collections/juniper/apstra/docs/index.rst
@@ -56,6 +56,7 @@ Modules
 * :ansplugin:`configlets module <juniper.apstra.configlets#module>` -- Manage configlets in Apstra
 * :ansplugin:`endpoint_policy module <juniper.apstra.endpoint_policy#module>` -- Manage endpoint policies in Apstra
 * :ansplugin:`generic_systems module <juniper.apstra.generic_systems#module>` -- Manage generic systems in Apstra blueprints
+* :ansplugin:`iba_probes module <juniper.apstra.iba_probes#module>` -- Manage IBA probes and dashboards in Apstra
 * :ansplugin:`resource_group module <juniper.apstra.resource_group#module>` -- Manage resource groups in Apstra
 * :ansplugin:`routing_policy module <juniper.apstra.routing_policy#module>` -- Manage routing policies in Apstra
 * :ansplugin:`resource_pools module <juniper.apstra.resource_pools#module>` -- Manage resource pools in Apstra
@@ -73,6 +74,7 @@ Modules
     configlets_module
     endpoint_policy_module
     generic_systems_module
+    iba_probes_module
     resource_group_module
     routing_policy_module
     resoource_pools_module

--- a/ansible_collections/juniper/apstra/galaxy.yml
+++ b/ansible_collections/juniper/apstra/galaxy.yml
@@ -1,7 +1,7 @@
 namespace: "juniper"
 description: "This collection provides modules to interact with Apstra."
 name: "apstra"
-version: "1.0.7"
+version: "1.0.6"
 readme: "README.md"
 authors:
     - "Pratik Dave <pratikd@juniper.net>"

--- a/ansible_collections/juniper/apstra/galaxy.yml
+++ b/ansible_collections/juniper/apstra/galaxy.yml
@@ -1,7 +1,7 @@
 namespace: "juniper"
 description: "This collection provides modules to interact with Apstra."
 name: "apstra"
-version: "1.0.6"
+version: "1.0.7"
 readme: "README.md"
 authors:
     - "Pratik Dave <pratikd@juniper.net>"

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/iba_probes.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/iba_probes.py
@@ -1,0 +1,433 @@
+# Copyright (c) 2024, Juniper Networks
+# BSD 3-Clause License
+
+"""IBA (Intent-Based Analytics) probe utilities.
+
+Provides reusable helpers for managing IBA probes within an Apstra
+blueprint via ``raw_request``.  The SDK does not expose a dedicated
+IBA probe endpoint, so this module uses the REST API directly —
+following the same pattern as ``bp_configlets.py``.
+
+API endpoints::
+
+    GET    /api/blueprints/{bp_id}/probes                                  → list probes
+    POST   /api/blueprints/{bp_id}/probes                                  → create custom probe
+    GET    /api/blueprints/{bp_id}/probes/{probe_id}                       → get probe
+    PUT    /api/blueprints/{bp_id}/probes/{probe_id}                       → update probe
+    DELETE /api/blueprints/{bp_id}/probes/{probe_id}                       → delete probe
+
+    GET    /api/blueprints/{bp_id}/iba/predefined-probes                   → list predefined probes
+    POST   /api/blueprints/{bp_id}/iba/predefined-probes/{name}            → instantiate predefined probe
+
+    GET    /api/blueprints/{bp_id}/iba/dashboards                          → list dashboards
+    POST   /api/blueprints/{bp_id}/iba/dashboards                          → create dashboard
+    GET    /api/blueprints/{bp_id}/iba/dashboards/{dashboard_id}           → get dashboard
+    PUT    /api/blueprints/{bp_id}/iba/dashboards/{dashboard_id}           → update dashboard
+    DELETE /api/blueprints/{bp_id}/iba/dashboards/{dashboard_id}           → delete dashboard
+
+Usage inside a module::
+
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.iba_probes import (
+        list_probes,
+        get_probe,
+        create_probe,
+        create_predefined_probe,
+        update_probe,
+        delete_probe,
+        find_probe_by_label,
+        list_predefined_probes,
+        get_predefined_probe,
+        list_dashboards,
+        get_dashboard,
+        create_dashboard,
+        update_dashboard,
+        delete_dashboard,
+        find_dashboard_by_label,
+    )
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import time
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Probe collection operations
+# ──────────────────────────────────────────────────────────────────
+
+
+def list_probes(client_factory, blueprint_id):
+    """List all probes in a blueprint.
+
+    Calls ``GET /api/blueprints/{bp_id}/probes``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+
+    Returns:
+        list[dict]: List of probe dicts.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/probes")
+    if resp.status_code == 200:
+        data = resp.json()
+        return data.get("items", [])
+    return []
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Probe single-resource operations
+# ──────────────────────────────────────────────────────────────────
+
+
+def get_probe(client_factory, blueprint_id, probe_id):
+    """Get a single probe by ID.
+
+    Calls ``GET /api/blueprints/{bp_id}/probes/{probe_id}``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        probe_id: The probe UUID.
+
+    Returns:
+        dict or None: The probe dict, or *None* if not found.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/probes/{probe_id}")
+    if resp.status_code == 200:
+        return resp.json()
+    return None
+
+
+def create_probe(client_factory, blueprint_id, body):
+    """Create a custom probe in a blueprint.
+
+    Calls ``POST /api/blueprints/{bp_id}/probes``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        body: The probe body dict (label, processors, etc.).
+
+    Returns:
+        dict: The created probe response (contains ``id``).
+
+    Raises:
+        Exception: If creation fails.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/probes", "POST", data=body)
+    if resp.status_code in (200, 201):
+        return resp.json()
+    raise Exception(f"Failed to create probe: {resp.status_code} {resp.text}")
+
+
+def create_predefined_probe(
+    client_factory, blueprint_id, predefined_probe_name, params
+):
+    """Instantiate a predefined probe in a blueprint.
+
+    Calls ``POST /api/blueprints/{bp_id}/iba/predefined-probes/{name}``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        predefined_probe_name: The predefined probe name (e.g. ``bgp_session``).
+        params: Dict of parameters matching the predefined probe schema
+                (e.g. ``{"label": "My Probe", "duration": 300}``).
+
+    Returns:
+        dict: Response containing the created probe ``id``.
+
+    Raises:
+        Exception: If instantiation fails.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/iba/predefined-probes/{predefined_probe_name}",
+        "POST",
+        data=params,
+    )
+    if resp.status_code in (200, 201):
+        return resp.json()
+    raise Exception(
+        f"Failed to instantiate predefined probe '{predefined_probe_name}': "
+        f"{resp.status_code} {resp.text}"
+    )
+
+
+def update_probe(client_factory, blueprint_id, probe_id, body):
+    """Update (PUT) a probe in a blueprint.
+
+    Calls ``PUT /api/blueprints/{bp_id}/probes/{probe_id}``.
+
+    The body should include ``label``, ``description``, ``disabled``,
+    and ``processors``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        probe_id: The probe UUID.
+        body: The full update body.
+
+    Raises:
+        Exception: If the update fails.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/probes/{probe_id}", "PUT", data=body
+    )
+    if resp.status_code not in (200, 202, 204):
+        raise Exception(f"Failed to update probe: {resp.status_code} {resp.text}")
+
+
+def delete_probe(client_factory, blueprint_id, probe_id):
+    """Delete a probe from a blueprint.
+
+    Calls ``DELETE /api/blueprints/{bp_id}/probes/{probe_id}``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        probe_id: The probe UUID.
+
+    Raises:
+        Exception: If deletion fails.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/probes/{probe_id}", "DELETE")
+    if resp.status_code not in (200, 202, 204):
+        raise Exception(f"Failed to delete probe: {resp.status_code} {resp.text}")
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Probe convenience helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+def find_probe_by_label(client_factory, blueprint_id, label):
+    """Find a probe by its label.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        label: The probe label to search for.
+
+    Returns:
+        dict or None: The matching probe dict, or *None*.
+    """
+    items = list_probes(client_factory, blueprint_id)
+    for item in items:
+        if isinstance(item, dict) and item.get("label") == label:
+            return item
+    return None
+
+
+def wait_for_probe_state(
+    client_factory,
+    blueprint_id,
+    probe_id,
+    target_state="operational",
+    timeout=120,
+    interval=5,
+):
+    """Poll a probe until it reaches the target state or timeout.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        probe_id: The probe UUID.
+        target_state: Desired ``state`` value (default ``operational``).
+        timeout: Max seconds to wait.
+        interval: Seconds between polls.
+
+    Returns:
+        dict: The probe dict once it reaches the target state.
+
+    Raises:
+        Exception: If the probe does not reach the target state within timeout.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        probe = get_probe(client_factory, blueprint_id, probe_id)
+        if probe and probe.get("state") == target_state:
+            return probe
+        time.sleep(interval)
+    raise Exception(
+        f"Probe {probe_id} did not reach state '{target_state}' within {timeout}s"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Predefined probe helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+def list_predefined_probes(client_factory, blueprint_id):
+    """List all predefined (built-in) probes available for a blueprint.
+
+    Calls ``GET /api/blueprints/{bp_id}/iba/predefined-probes``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+
+    Returns:
+        list[dict]: List of predefined probe dicts (each has ``name``,
+        ``schema``, ``description``).
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/iba/predefined-probes")
+    if resp.status_code == 200:
+        data = resp.json()
+        return data.get("items", [])
+    return []
+
+
+def get_predefined_probe(client_factory, blueprint_id, name):
+    """Find a predefined probe by name.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        name: The predefined probe name (e.g. ``bgp_session``).
+
+    Returns:
+        dict or None: The predefined probe dict, or *None*.
+    """
+    items = list_predefined_probes(client_factory, blueprint_id)
+    for item in items:
+        if isinstance(item, dict) and item.get("name") == name:
+            return item
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Dashboard operations
+# ──────────────────────────────────────────────────────────────────
+
+
+def list_dashboards(client_factory, blueprint_id):
+    """List all IBA dashboards in a blueprint.
+
+    Calls ``GET /api/blueprints/{bp_id}/iba/dashboards``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+
+    Returns:
+        list[dict]: List of dashboard dicts.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/iba/dashboards")
+    if resp.status_code == 200:
+        data = resp.json()
+        return data.get("items", [])
+    return []
+
+
+def get_dashboard(client_factory, blueprint_id, dashboard_id):
+    """Get a single IBA dashboard by ID.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        dashboard_id: The dashboard UUID.
+
+    Returns:
+        dict or None: The dashboard dict, or *None*.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/iba/dashboards/{dashboard_id}")
+    if resp.status_code == 200:
+        return resp.json()
+    return None
+
+
+def create_dashboard(client_factory, blueprint_id, body):
+    """Create an IBA dashboard in a blueprint.
+
+    Calls ``POST /api/blueprints/{bp_id}/iba/dashboards``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        body: The dashboard body dict.
+
+    Returns:
+        dict: The created dashboard response (contains ``id``).
+
+    Raises:
+        Exception: If creation fails.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/iba/dashboards", "POST", data=body
+    )
+    if resp.status_code in (200, 201):
+        return resp.json()
+    raise Exception(f"Failed to create dashboard: {resp.status_code} {resp.text}")
+
+
+def update_dashboard(client_factory, blueprint_id, dashboard_id, body):
+    """Update (PUT) an IBA dashboard.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        dashboard_id: The dashboard UUID.
+        body: The full update body.
+
+    Raises:
+        Exception: If the update fails.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/iba/dashboards/{dashboard_id}",
+        "PUT",
+        data=body,
+    )
+    if resp.status_code not in (200, 202, 204):
+        raise Exception(f"Failed to update dashboard: {resp.status_code} {resp.text}")
+
+
+def delete_dashboard(client_factory, blueprint_id, dashboard_id):
+    """Delete an IBA dashboard.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        dashboard_id: The dashboard UUID.
+
+    Raises:
+        Exception: If deletion fails.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/iba/dashboards/{dashboard_id}", "DELETE"
+    )
+    if resp.status_code not in (200, 202, 204):
+        raise Exception(f"Failed to delete dashboard: {resp.status_code} {resp.text}")
+
+
+def find_dashboard_by_label(client_factory, blueprint_id, label):
+    """Find an IBA dashboard by its label.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        label: The dashboard label to search for.
+
+    Returns:
+        dict or None: The matching dashboard dict, or *None*.
+    """
+    items = list_dashboards(client_factory, blueprint_id)
+    for item in items:
+        if isinstance(item, dict) and item.get("label") == label:
+            return item
+    return None

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -573,6 +573,107 @@ def resolve_application_point_ids(client_factory, blueprint_id, ap_refs):
 
 
 # ──────────────────────────────────────────────────────────────────
+#  IBA Probe resolution
+# ──────────────────────────────────────────────────────────────────
+
+
+def resolve_probe_id(client_factory, blueprint_id, probe_ref):
+    """Resolve an IBA probe reference (UUID or label) to its probe ID.
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param blueprint_id: The blueprint UUID.
+    :param probe_ref: The probe UUID or label.
+    :return: The resolved probe ID string.
+    :raises ValueError: If no matching probe is found.
+    """
+    if not probe_ref:
+        return probe_ref
+
+    # Fast path: already a UUID
+    if _is_uuid(probe_ref):
+        return probe_ref
+
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/probes")
+    if resp.status_code != 200:
+        raise ValueError(
+            f"Failed to list probes in blueprint '{blueprint_id}': "
+            f"{resp.status_code} {resp.text}"
+        )
+    all_probes = resp.json().get("items", [])
+
+    # Exact ID match (non-UUID IDs)
+    for p in all_probes:
+        if p.get("id") == probe_ref:
+            return probe_ref
+
+    # Exact label match
+    for p in all_probes:
+        if p.get("label") == probe_ref:
+            return p["id"]
+
+    # Case-insensitive label fallback
+    ref_lower = probe_ref.lower()
+    for p in all_probes:
+        if (p.get("label") or "").lower() == ref_lower:
+            return p["id"]
+
+    available = [p.get("label", "") for p in all_probes]
+    raise ValueError(
+        f"Probe '{probe_ref}' not found in blueprint '{blueprint_id}'. "
+        f"Available: {available}"
+    )
+
+
+def resolve_dashboard_id(client_factory, blueprint_id, dashboard_ref):
+    """Resolve an IBA dashboard reference (UUID or label) to its dashboard ID.
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param blueprint_id: The blueprint UUID.
+    :param dashboard_ref: The dashboard UUID or label.
+    :return: The resolved dashboard ID string.
+    :raises ValueError: If no matching dashboard is found.
+    """
+    if not dashboard_ref:
+        return dashboard_ref
+
+    # Fast path: already a UUID
+    if _is_uuid(dashboard_ref):
+        return dashboard_ref
+
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/iba/dashboards")
+    if resp.status_code != 200:
+        raise ValueError(
+            f"Failed to list dashboards in blueprint '{blueprint_id}': "
+            f"{resp.status_code} {resp.text}"
+        )
+    all_dashboards = resp.json().get("items", [])
+
+    # Exact ID match (non-UUID IDs)
+    for d in all_dashboards:
+        if d.get("id") == dashboard_ref:
+            return dashboard_ref
+
+    # Exact label match
+    for d in all_dashboards:
+        if d.get("label") == dashboard_ref:
+            return d["id"]
+
+    # Case-insensitive label fallback
+    ref_lower = dashboard_ref.lower()
+    for d in all_dashboards:
+        if (d.get("label") or "").lower() == ref_lower:
+            return d["id"]
+
+    available = [d.get("label", "") for d in all_dashboards]
+    raise ValueError(
+        f"Dashboard '{dashboard_ref}' not found in blueprint '{blueprint_id}'. "
+        f"Available: {available}"
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
 #  Virtual Network resolution  (Phase 4)
 # ──────────────────────────────────────────────────────────────────
 

--- a/ansible_collections/juniper/apstra/plugins/modules/iba_probes.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/iba_probes.py
@@ -1,0 +1,850 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024, Juniper Networks
+# BSD 3-Clause License
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.iba_probes import (
+    list_probes,
+    get_probe,
+    create_probe,
+    create_predefined_probe,
+    update_probe,
+    delete_probe,
+    find_probe_by_label,
+    list_predefined_probes,
+    get_predefined_probe,
+    list_dashboards,
+    get_dashboard,
+    create_dashboard,
+    update_dashboard,
+    delete_dashboard,
+    find_dashboard_by_label,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_probe_id,
+    resolve_dashboard_id,
+)
+
+DOCUMENTATION = """
+---
+module: iba_probes
+
+short_description: Manage IBA (Intent-Based Analytics) probes in Apstra
+
+version_added: "0.1.0"
+
+author:
+  - "Prabhanjan KV (@kvp_jnpr)"
+
+description:
+  - This module allows you to create, update, delete, and query IBA probes in Apstra blueprints.
+  - Supports instantiation of predefined (built-in) probes as well as custom probe definitions.
+  - Also manages IBA dashboards for probe visualisation.
+  - Predefined probes are instantiated from a catalog of 48+ built-in probe types including
+    bgp_session, traffic, device_health, ecmp_imbalance, lag_imbalance, and many more.
+  - Custom probes can be created with user-defined processors and stages.
+  - Probes monitor fabric health, traffic patterns, anomalies, and more.
+
+options:
+  api_url:
+    description:
+      - The URL used to access the Apstra api.
+    type: str
+    required: false
+    default: APSTRA_API_URL environment variable
+  verify_certificates:
+    description:
+      - If set to false, SSL certificates will not be verified.
+    type: bool
+    required: false
+    default: True
+  username:
+    description:
+      - The username for authentication.
+    type: str
+    required: false
+    default: APSTRA_USERNAME environment variable
+  password:
+    description:
+      - The password for authentication.
+    type: str
+    required: false
+    default: APSTRA_PASSWORD environment variable
+  auth_token:
+    description:
+      - The authentication token to use if already authenticated.
+    type: str
+    required: false
+    default: APSTRA_AUTH_TOKEN environment variable
+  type:
+    description:
+      - The type of IBA resource to manage.
+      - C(predefined) instantiates a probe from the Apstra predefined probe catalog.
+      - C(probe) manages custom (raw) probes directly.
+      - C(dashboard) manages IBA dashboards.
+    required: false
+    type: str
+    choices: ["predefined", "probe", "dashboard"]
+    default: "predefined"
+  id:
+    description:
+      - Dictionary containing resource identifiers.
+      - Always requires C(blueprint) key with the blueprint UUID or label.
+      - For existing probes, include C(probe) key with probe UUID or label.
+      - For dashboards, include C(dashboard) key with dashboard UUID or label.
+      - Name/label resolution is supported for C(blueprint), C(probe), and C(dashboard) keys.
+    required: false
+    type: dict
+  body:
+    description:
+      - Dictionary containing the resource details.
+      - For predefined probes, C(predefined_probe) is the probe name (e.g. C(bgp_session)),
+        and additional keys are the schema parameters (C(label), C(duration), etc.).
+      - For custom probes, keys include C(label), C(description), C(disabled), and C(processors).
+      - For dashboards, keys include C(label) and C(description).
+    required: false
+    type: dict
+  state:
+    description:
+      - Desired state of the resource.
+      - C(present) creates or updates the resource.
+      - C(absent) deletes the resource.
+    required: false
+    type: str
+    choices: ["present", "absent"]
+    default: "present"
+"""
+
+EXAMPLES = """
+# ── Predefined Probes ───────────────────────────────────────────────
+
+- name: Authenticate to Apstra
+  juniper.apstra.authenticate:
+    logout: false
+  register: auth
+
+- name: Create a BGP Session probe from predefined
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: bgp_session
+      label: "BGP Monitoring"
+      duration: 300
+      threshold: 40
+    auth_token: "{{ auth.token }}"
+  register: bgp_probe
+
+- name: Create a Device Traffic probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: traffic
+      label: "Device Traffic"
+    auth_token: "{{ auth.token }}"
+
+- name: Create a Device System Health probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: device_health
+      label: "Device System Health"
+      raise_switch_anomaly: true
+      raise_server_anomaly: true
+      history_duration: 2592000
+    auth_token: "{{ auth.token }}"
+
+- name: Create an ECMP Imbalance probe (fabric)
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: fabric_ecmp_imbalance
+      label: "ECMP Imbalance (Fabric Interfaces)"
+    auth_token: "{{ auth.token }}"
+
+- name: Create a LAG Imbalance probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: lag_imbalance
+      label: "LAG Imbalance"
+    auth_token: "{{ auth.token }}"
+
+- name: Create a Control Plane Policing probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: copp
+      label: "Control Plane Policing"
+      aggregation_period: 300
+      collection_interval: 120
+      history_duration: 2592000
+      drop_count_threshold: 1
+    auth_token: "{{ auth.token }}"
+
+- name: Create a Device Telemetry Health probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: device_telemetry_health
+      label: "Device Telemetry Health"
+    auth_token: "{{ auth.token }}"
+
+- name: Create an ESI Imbalance probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: esi_imbalance
+      label: "ESI Imbalance"
+    auth_token: "{{ auth.token }}"
+
+- name: Create a MAC Monitor probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: mac_monitor
+      label: "MAC Monitor"
+    auth_token: "{{ auth.token }}"
+
+- name: Create a Bandwidth Utilization probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: bandwidth_utilization
+      label: "Bandwidth Utilization"
+      first_summary_average_period: 120
+      first_summary_total_duration: 3600
+      second_summary_average_period: 3600
+      second_summary_total_duration: 2592000
+    auth_token: "{{ auth.token }}"
+
+- name: Create a Spine Fault Tolerance probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: spine_fault_tolerance
+      label: "Spine Fault Tolerance"
+    auth_token: "{{ auth.token }}"
+
+- name: Create an Optical Transceivers probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: optical_transceivers
+      label: "Optical Transceivers"
+    auth_token: "{{ auth.token }}"
+
+- name: Create an Interface Flapping probe (fabric)
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: fabric_interface_flapping
+      label: "Interface Flapping (Fabric)"
+    auth_token: "{{ auth.token }}"
+
+- name: Create an EVPN Host Flapping probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: evpn_host_flapping
+      label: "EVPN Host Flapping"
+    auth_token: "{{ auth.token }}"
+
+- name: Create a Packet Discard Percentage probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: packet_discard_percentage
+      label: "Packet Discard Percentage"
+    auth_token: "{{ auth.token }}"
+
+- name: Create an East-West Traffic probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: eastwest_traffic
+      label: "East-West Traffic"
+    auth_token: "{{ auth.token }}"
+
+- name: Create an External Routes probe
+  juniper.apstra.iba_probes:
+    type: predefined
+    id:
+      blueprint: "my-blueprint"
+    body:
+      predefined_probe: external_routes
+      label: "External Routes"
+    auth_token: "{{ auth.token }}"
+
+# ── Update / Delete Probes ──────────────────────────────────────────
+
+- name: Update a probe's label (by current label lookup)
+  juniper.apstra.iba_probes:
+    type: probe
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "BGP Monitoring"
+      description: "Updated BGP probe description"
+    state: present
+    auth_token: "{{ auth.token }}"
+
+- name: Delete a probe by ID
+  juniper.apstra.iba_probes:
+    type: probe
+    id:
+      blueprint: "my-blueprint"
+      probe: "{{ bgp_probe.id.probe }}"
+    state: absent
+    auth_token: "{{ auth.token }}"
+
+- name: Delete a probe by label (via id.probe)
+  juniper.apstra.iba_probes:
+    type: probe
+    id:
+      blueprint: "my-blueprint"
+      probe: "BGP Monitoring"
+    state: absent
+    auth_token: "{{ auth.token }}"
+
+- name: Read a probe by label (via id.probe)
+  juniper.apstra.iba_probes:
+    type: probe
+    id:
+      blueprint: "my-blueprint"
+      probe: "BGP Monitoring"
+    state: present
+    auth_token: "{{ auth.token }}"
+
+- name: Delete a probe by label (via body.label fallback)
+  juniper.apstra.iba_probes:
+    type: probe
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "BGP Monitoring"
+    state: absent
+    auth_token: "{{ auth.token }}"
+
+# ── IBA Dashboards ──────────────────────────────────────────────────
+
+- name: Create an IBA dashboard
+  juniper.apstra.iba_probes:
+    type: dashboard
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "Fabric Health Dashboard"
+      description: "Overview of fabric health probes"
+    state: present
+    auth_token: "{{ auth.token }}"
+  register: dash
+
+- name: Delete an IBA dashboard by ID
+  juniper.apstra.iba_probes:
+    type: dashboard
+    id:
+      blueprint: "my-blueprint"
+      dashboard: "{{ dash.id.dashboard }}"
+    state: absent
+    auth_token: "{{ auth.token }}"
+
+- name: Delete an IBA dashboard by label
+  juniper.apstra.iba_probes:
+    type: dashboard
+    id:
+      blueprint: "my-blueprint"
+      dashboard: "Fabric Health Dashboard"
+    state: absent
+    auth_token: "{{ auth.token }}"
+
+- name: Read an IBA dashboard by label
+  juniper.apstra.iba_probes:
+    type: dashboard
+    id:
+      blueprint: "my-blueprint"
+      dashboard: "Fabric Health Dashboard"
+    state: present
+    auth_token: "{{ auth.token }}"
+"""
+
+RETURN = """
+changed:
+  description: Indicates whether the module has made any changes.
+  type: bool
+  returned: always
+id:
+  description: Dictionary of resource identifiers.
+  returned: on create or when found by label
+  type: dict
+  sample: {
+      "blueprint": "54bd9839-275e-4444-8ef2-5093f49e08b7",
+      "probe": "99a47423-c172-4006-b55a-da37102f73e4"
+  }
+probe:
+  description: The full probe object details.
+  returned: when type is predefined or probe with state present
+  type: dict
+dashboard:
+  description: The full dashboard object details.
+  returned: when type is dashboard with state present
+  type: dict
+changes:
+  description: Dictionary of updates that were applied.
+  type: dict
+  returned: on update
+msg:
+  description: The output message that the module generates.
+  type: str
+  returned: always
+predefined_probes:
+  description: List of available predefined probe names (when listing).
+  type: list
+  returned: when state is present and type is predefined with no body
+"""
+
+# Read-only fields returned by the API but not part of the create/update body
+PROBE_READ_ONLY_FIELDS = (
+    "id",
+    "stages",
+    "state",
+    "probe_state",
+    "last_error",
+    "config_started_at",
+    "config_completed_at",
+    "anomaly_count",
+    "version",
+    "iba_unit",
+    "host_node",
+    "task_state",
+    "task_error",
+    "predefined_probe",
+    "referencing_dashboards",
+    "updated_at",
+    "created_by",
+    "updated_by",
+)
+
+DASHBOARD_READ_ONLY_FIELDS = (
+    "id",
+    "created_at",
+    "updated_at",
+    "created_by",
+    "updated_by",
+    "default",
+    "predefined_dashboard",
+    "predefined_parameters",
+)
+
+
+def _manage_predefined_probe(module, client_factory):
+    """Manage a predefined (built-in) probe."""
+    result = dict(changed=False)
+
+    id_param = module.params.get("id")
+    if id_param is None:
+        id_param = {}
+    body = module.params.get("body", None)
+    state = module.params["state"]
+
+    blueprint_id = id_param.get("blueprint")
+    if not blueprint_id:
+        raise ValueError("Must specify 'blueprint' in id")
+    blueprint_id = client_factory.resolve_blueprint_id(blueprint_id)
+    id_param["blueprint"] = blueprint_id
+
+    if state == "present":
+        if body is None:
+            # List available predefined probes
+            predefined = list_predefined_probes(client_factory, blueprint_id)
+            result["predefined_probes"] = [p.get("name") for p in predefined]
+            result["msg"] = f"Found {len(predefined)} predefined probes"
+            return result
+
+        predefined_probe_name = body.get("predefined_probe")
+        if not predefined_probe_name:
+            raise ValueError(
+                "Must specify 'predefined_probe' in body for predefined type "
+                "(e.g. bgp_session, traffic, device_health)"
+            )
+
+        label = body.get("label")
+
+        # Check if a probe with this label already exists
+        if label:
+            existing = find_probe_by_label(client_factory, blueprint_id, label)
+            if existing:
+                probe_id = existing["id"]
+                id_param["probe"] = probe_id
+                result["id"] = id_param
+                result["changed"] = False
+                result["probe"] = existing
+                result["msg"] = f"Probe '{label}' already exists"
+                return result
+
+        # Build the params for instantiation (everything except predefined_probe)
+        params = {k: v for k, v in body.items() if k != "predefined_probe"}
+
+        # Validate the predefined probe exists
+        predef = get_predefined_probe(
+            client_factory, blueprint_id, predefined_probe_name
+        )
+        if predef is None:
+            available = list_predefined_probes(client_factory, blueprint_id)
+            available_names = [p.get("name") for p in available]
+            raise ValueError(
+                f"Predefined probe '{predefined_probe_name}' not found. "
+                f"Available: {available_names}"
+            )
+
+        created = create_predefined_probe(
+            client_factory, blueprint_id, predefined_probe_name, params
+        )
+        probe_id = created.get("id")
+        if not probe_id:
+            raise ValueError(
+                f"Unexpected response from predefined probe creation: {created}"
+            )
+
+        id_param["probe"] = probe_id
+        result["id"] = id_param
+        result["changed"] = True
+        result["msg"] = (
+            f"Predefined probe '{predefined_probe_name}' instantiated successfully"
+        )
+
+        # Fetch the full probe
+        import time
+
+        for _ in range(10):
+            probe = get_probe(client_factory, blueprint_id, probe_id)
+            if probe is not None:
+                break
+            time.sleep(2)
+        result["probe"] = probe
+
+    elif state == "absent":
+        probe_id = id_param.get("probe")
+        label = body.get("label") if body else None
+
+        # Resolve probe ref (UUID or label) via name_resolution
+        if probe_id:
+            probe_id = resolve_probe_id(client_factory, blueprint_id, probe_id)
+            id_param["probe"] = probe_id
+        elif label:
+            existing = find_probe_by_label(client_factory, blueprint_id, label)
+            if existing:
+                probe_id = existing["id"]
+                id_param["probe"] = probe_id
+
+        if not probe_id:
+            result["changed"] = False
+            result["msg"] = "Probe not found, nothing to delete"
+            return result
+
+        delete_probe(client_factory, blueprint_id, probe_id)
+        result["changed"] = True
+        result["msg"] = "Probe deleted successfully"
+
+    return result
+
+
+def _manage_custom_probe(module, client_factory):
+    """Manage a custom (raw) probe."""
+    result = dict(changed=False)
+
+    id_param = module.params.get("id")
+    if id_param is None:
+        id_param = {}
+    body = module.params.get("body", None)
+    state = module.params["state"]
+
+    blueprint_id = id_param.get("blueprint")
+    if not blueprint_id:
+        raise ValueError("Must specify 'blueprint' in id")
+    blueprint_id = client_factory.resolve_blueprint_id(blueprint_id)
+    id_param["blueprint"] = blueprint_id
+
+    probe_id = id_param.get("probe")
+
+    # Resolve probe ref (UUID or label) via name_resolution
+    if probe_id:
+        probe_id = resolve_probe_id(client_factory, blueprint_id, probe_id)
+        id_param["probe"] = probe_id
+
+    # Try to find by label if no probe ID given
+    current_object = None
+    if probe_id is None:
+        label = body.get("label") if body else None
+        if label:
+            found = find_probe_by_label(client_factory, blueprint_id, label)
+            if found:
+                probe_id = found["id"]
+                id_param["probe"] = probe_id
+                current_object = found
+    else:
+        current_object = get_probe(client_factory, blueprint_id, probe_id)
+
+    if state == "present":
+        if current_object:
+            result["id"] = id_param
+            if body:
+                # Compare updatable fields
+                compare_current = {
+                    k: v
+                    for k, v in current_object.items()
+                    if k not in PROBE_READ_ONLY_FIELDS
+                }
+                changes = {}
+                if client_factory.compare_and_update(compare_current, body, changes):
+                    update_probe(
+                        client_factory, blueprint_id, probe_id, compare_current
+                    )
+                    result["changed"] = True
+                    result["changes"] = changes
+                    result["msg"] = "Probe updated successfully"
+                else:
+                    result["changed"] = False
+                    result["msg"] = "No changes needed for probe"
+            else:
+                result["changed"] = False
+                result["msg"] = "No changes specified for probe"
+
+            # Return final state
+            if result["changed"]:
+                import time
+
+                for _ in range(10):
+                    probe = get_probe(client_factory, blueprint_id, probe_id)
+                    if probe is not None:
+                        break
+                    time.sleep(2)
+                result["probe"] = probe
+            else:
+                result["probe"] = current_object
+        else:
+            # Create custom probe
+            if body is None:
+                raise ValueError("Must specify 'body' to create a probe")
+            created = create_probe(client_factory, blueprint_id, body)
+            probe_id = created.get("id")
+            if not probe_id:
+                raise ValueError(f"Unexpected response creating probe: {created}")
+            id_param["probe"] = probe_id
+            result["id"] = id_param
+            result["changed"] = True
+            result["msg"] = "Probe created successfully"
+
+            import time
+
+            for _ in range(10):
+                probe = get_probe(client_factory, blueprint_id, probe_id)
+                if probe is not None:
+                    break
+                time.sleep(2)
+            result["probe"] = probe
+
+    elif state == "absent":
+        if current_object is None:
+            result["changed"] = False
+            result["msg"] = "Probe does not exist"
+        else:
+            if not probe_id:
+                raise ValueError("Cannot delete a probe without a probe id")
+            delete_probe(client_factory, blueprint_id, probe_id)
+            result["changed"] = True
+            result["msg"] = "Probe deleted successfully"
+
+    return result
+
+
+def _manage_dashboard(module, client_factory):
+    """Manage an IBA dashboard."""
+    result = dict(changed=False)
+
+    id_param = module.params.get("id")
+    if id_param is None:
+        id_param = {}
+    body = module.params.get("body", None)
+    state = module.params["state"]
+
+    blueprint_id = id_param.get("blueprint")
+    if not blueprint_id:
+        raise ValueError("Must specify 'blueprint' in id")
+    blueprint_id = client_factory.resolve_blueprint_id(blueprint_id)
+    id_param["blueprint"] = blueprint_id
+
+    dashboard_id = id_param.get("dashboard")
+
+    # Resolve dashboard ref (UUID or label) via name_resolution
+    if dashboard_id:
+        dashboard_id = resolve_dashboard_id(client_factory, blueprint_id, dashboard_id)
+        id_param["dashboard"] = dashboard_id
+
+    # Try to find by label if no dashboard ID given
+    current_object = None
+    if dashboard_id is None:
+        label = body.get("label") if body else None
+        if label:
+            found = find_dashboard_by_label(client_factory, blueprint_id, label)
+            if found:
+                dashboard_id = found["id"]
+                id_param["dashboard"] = dashboard_id
+                current_object = found
+    else:
+        current_object = get_dashboard(client_factory, blueprint_id, dashboard_id)
+
+    if state == "present":
+        if current_object:
+            result["id"] = id_param
+            if body:
+                compare_current = {
+                    k: v
+                    for k, v in current_object.items()
+                    if k not in DASHBOARD_READ_ONLY_FIELDS
+                }
+                changes = {}
+                if client_factory.compare_and_update(compare_current, body, changes):
+                    update_dashboard(
+                        client_factory, blueprint_id, dashboard_id, compare_current
+                    )
+                    result["changed"] = True
+                    result["changes"] = changes
+                    result["msg"] = "Dashboard updated successfully"
+                else:
+                    result["changed"] = False
+                    result["msg"] = "No changes needed for dashboard"
+            else:
+                result["changed"] = False
+                result["msg"] = "No changes specified for dashboard"
+
+            result["dashboard"] = current_object
+
+        else:
+            if body is None:
+                raise ValueError("Must specify 'body' to create a dashboard")
+            # The API requires 'grid' with at least one row; default to one empty row
+            if "grid" not in body:
+                body["grid"] = [[]]
+            created = create_dashboard(client_factory, blueprint_id, body)
+            dashboard_id = created.get("id")
+            if not dashboard_id:
+                raise ValueError(f"Unexpected response creating dashboard: {created}")
+            id_param["dashboard"] = dashboard_id
+            result["id"] = id_param
+            result["changed"] = True
+            result["msg"] = "Dashboard created successfully"
+
+            import time
+
+            for _ in range(10):
+                dash = get_dashboard(client_factory, blueprint_id, dashboard_id)
+                if dash is not None:
+                    break
+                time.sleep(2)
+            result["dashboard"] = dash
+
+    elif state == "absent":
+        if current_object is None:
+            result["changed"] = False
+            result["msg"] = "Dashboard does not exist"
+        else:
+            if not dashboard_id:
+                raise ValueError("Cannot delete a dashboard without a dashboard id")
+            delete_dashboard(client_factory, blueprint_id, dashboard_id)
+            result["changed"] = True
+            result["msg"] = "Dashboard deleted successfully"
+
+    return result
+
+
+def main():
+    object_module_args = dict(
+        type=dict(
+            type="str",
+            required=False,
+            choices=["predefined", "probe", "dashboard"],
+            default="predefined",
+        ),
+        id=dict(type="dict", required=False, default=None),
+        body=dict(type="dict", required=False),
+        state=dict(
+            type="str",
+            required=False,
+            choices=["present", "absent"],
+            default="present",
+        ),
+    )
+    client_module_args = apstra_client_module_args()
+    module_args = client_module_args | object_module_args
+
+    result = dict(changed=False)
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    try:
+        client_factory = ApstraClientFactory.from_params(module)
+
+        resource_type = module.params["type"]
+
+        if resource_type == "predefined":
+            result = _manage_predefined_probe(module, client_factory)
+        elif resource_type == "probe":
+            result = _manage_custom_probe(module, client_factory)
+        elif resource_type == "dashboard":
+            result = _manage_dashboard(module, client_factory)
+        else:
+            raise ValueError(f"Unsupported type: {resource_type}")
+
+    except Exception as e:
+        tb = traceback.format_exc()
+        module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        module.fail_json(msg=str(e), **result)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/juniper/apstra/tests/iba_probes.yml
+++ b/ansible_collections/juniper/apstra/tests/iba_probes.yml
@@ -1,0 +1,629 @@
+---
+# =============================================================================
+# IBA Probes — Full CRUD End-to-End Test Playbook
+# =============================================================================
+#
+# This playbook tests the juniper.apstra.iba_probes module by:
+#   1. Authenticating to Apstra
+#   2. Creating a fresh blueprint for testing
+#   3. Listing available predefined probes
+#   4. Creating probes from various predefined types (CRUD - Create)
+#   5. Verifying created probes exist (CRUD - Read)
+#   6. Updating probe properties (CRUD - Update)
+#   7. Testing idempotency (re-running create should detect no changes)
+#   8. Deleting all test probes (CRUD - Delete)
+#   9. Verifying deletion
+#   10. Testing IBA dashboards CRUD
+#   11. Deleting the blueprint
+#
+# Usage:
+#   cd apstra-ansible-collection
+#   make test-iba_probes
+#
+# Environment variables (or set in .env):
+#   APSTRA_API_URL, APSTRA_USERNAME, APSTRA_PASSWORD, APSTRA_VERIFY_CERTIFICATES
+# =============================================================================
+
+- name: IBA Probes — Full CRUD Test
+  hosts: localhost
+  gather_facts: false
+  connection: local
+
+  vars:
+    # Override these via -e if needed
+    blueprint_label: "iba-probes-test-bp"
+    blueprint_template: "L2 Virtual EVPN"
+
+  tasks:
+    # ─── Authentication ───────────────────────────────────────────────
+    - name: Authenticate to Apstra
+      juniper.apstra.authenticate:
+        logout: false
+      register: auth
+
+    - name: Display auth token (truncated)
+      ansible.builtin.debug:
+        msg: "Authenticated. Token: {{ auth.token[:16] }}..."
+
+    # ─── Blueprint Creation ───────────────────────────────────────────
+    - name: "SETUP — Create test blueprint"
+      juniper.apstra.blueprint:
+        body:
+          label: "{{ blueprint_label }}"
+          design: "two_stage_l3clos"
+          init_type: "template_reference"
+          template_id: "{{ blueprint_template }}"
+        lock_state: "ignore"
+        auth_token: "{{ auth.token }}"
+      register: bp
+
+    - name: Show blueprint ID
+      ansible.builtin.debug:
+        msg: "Blueprint: {{ blueprint_label }} → {{ bp.id.blueprint }}"
+
+    # ─── List Predefined Probes ───────────────────────────────────────
+    - name: List all available predefined probes
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: predefined_list
+
+    - name: Show predefined probe count
+      ansible.builtin.debug:
+        msg: "Available predefined probes: {{ predefined_list.predefined_probes | length }}"
+
+    - name: Show predefined probe names
+      ansible.builtin.debug:
+        msg: "{{ predefined_list.predefined_probes }}"
+
+    # ═════════════════════════════════════════════════════════════════
+    # CREATE — Instantiate various predefined probes
+    # ═════════════════════════════════════════════════════════════════
+
+    - name: "CREATE — BGP Session probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: bgp_session
+          label: "Test - BGP Monitoring"
+          duration: 300
+          threshold: 40
+        auth_token: "{{ auth.token }}"
+      register: probe_bgp
+
+    - name: Verify BGP probe creation
+      ansible.builtin.assert:
+        that:
+          - probe_bgp.changed == true
+          - probe_bgp.id.probe is defined
+          - probe_bgp.probe.label == "Test - BGP Monitoring"
+        fail_msg: "BGP probe creation failed"
+
+    - name: "CREATE — Bandwidth Utilization probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: bandwidth_utilization
+          label: "Test - Bandwidth Utilization"
+          first_summary_average_period: 120
+          first_summary_total_duration: 3600
+          second_summary_average_period: 3600
+          second_summary_total_duration: 2592000
+        auth_token: "{{ auth.token }}"
+      register: probe_bw
+
+    - name: Verify Bandwidth probe creation
+      ansible.builtin.assert:
+        that:
+          - probe_bw.changed == true
+          - probe_bw.id.probe is defined
+        fail_msg: "Bandwidth probe creation failed"
+
+    - name: "CREATE — Control Plane Policing probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: copp
+          label: "Test - Control Plane Policing"
+          aggregation_period: 300
+          collection_interval: 120
+          history_duration: 2592000
+          drop_count_threshold: 1
+        auth_token: "{{ auth.token }}"
+      register: probe_copp
+
+    - name: Verify COPP probe creation
+      ansible.builtin.assert:
+        that:
+          - probe_copp.changed == true
+          - probe_copp.id.probe is defined
+        fail_msg: "COPP probe creation failed"
+
+    - name: "CREATE — Device System Health probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: device_health
+          label: "Test - Device System Health"
+          raise_switch_anomaly: true
+          raise_server_anomaly: true
+          history_duration: 2592000
+        auth_token: "{{ auth.token }}"
+      register: probe_health
+
+    - name: Verify Device Health probe creation
+      ansible.builtin.assert:
+        that:
+          - probe_health.changed == true
+          - probe_health.id.probe is defined
+        fail_msg: "Device Health probe creation failed"
+
+    - name: "CREATE — Device Telemetry Health probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: device_telemetry_health
+          label: "Test - Device Telemetry Health"
+        auth_token: "{{ auth.token }}"
+      register: probe_telemetry
+
+    - name: Verify Device Telemetry probe creation
+      ansible.builtin.assert:
+        that:
+          - probe_telemetry.changed == true
+        fail_msg: "Device Telemetry probe creation failed"
+
+    - name: "CREATE — LAG Imbalance probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: lag_imbalance
+          label: "Test - LAG Imbalance"
+        auth_token: "{{ auth.token }}"
+      register: probe_lag
+
+    - name: "CREATE — Fabric ECMP Imbalance probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: fabric_ecmp_imbalance
+          label: "Test - Fabric ECMP Imbalance"
+        auth_token: "{{ auth.token }}"
+      register: probe_ecmp
+
+    - name: "CREATE — ESI Imbalance probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: esi_imbalance
+          label: "Test - ESI Imbalance"
+        auth_token: "{{ auth.token }}"
+      register: probe_esi
+
+    - name: "CREATE — MAC Monitor probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: mac_monitor
+          label: "Test - MAC Monitor"
+        auth_token: "{{ auth.token }}"
+      register: probe_mac
+
+    - name: Show all created probe IDs
+      ansible.builtin.debug:
+        msg:
+          - "BGP: {{ probe_bgp.id.probe }}"
+          - "Bandwidth: {{ probe_bw.id.probe }}"
+          - "COPP: {{ probe_copp.id.probe }}"
+          - "Health: {{ probe_health.id.probe }}"
+          - "Telemetry: {{ probe_telemetry.id.probe }}"
+          - "LAG: {{ probe_lag.id.probe }}"
+          - "ECMP: {{ probe_ecmp.id.probe }}"
+          - "ESI: {{ probe_esi.id.probe }}"
+          - "MAC: {{ probe_mac.id.probe }}"
+
+    # ═════════════════════════════════════════════════════════════════
+    # READ — Verify probes exist by re-fetching
+    # ═════════════════════════════════════════════════════════════════
+
+    - name: "READ — Fetch BGP probe by ID (via probe type)"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_bgp.id.probe }}"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: read_bgp
+
+    - name: Verify READ returns the probe
+      ansible.builtin.assert:
+        that:
+          - read_bgp.changed == false
+          - read_bgp.probe.label == "Test - BGP Monitoring"
+        fail_msg: "Failed to read back BGP probe"
+
+    # ═════════════════════════════════════════════════════════════════
+    # READ BY LABEL — Fetch probes using label in id.probe
+    # ═════════════════════════════════════════════════════════════════
+
+    - name: "READ BY LABEL — Fetch BGP probe by label (via id.probe)"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "Test - BGP Monitoring"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: read_bgp_label
+
+    - name: Verify READ by label returns the same probe
+      ansible.builtin.assert:
+        that:
+          - read_bgp_label.changed == false
+          - read_bgp_label.probe.label == "Test - BGP Monitoring"
+          - read_bgp_label.probe.id == probe_bgp.id.probe
+        fail_msg: "Failed to read BGP probe by label"
+
+    - name: "READ BY LABEL — Fetch Bandwidth probe by label"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "Test - Bandwidth Utilization"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: read_bw_label
+
+    - name: Verify Bandwidth probe read by label
+      ansible.builtin.assert:
+        that:
+          - read_bw_label.changed == false
+          - read_bw_label.probe.id == probe_bw.id.probe
+        fail_msg: "Failed to read Bandwidth probe by label"
+
+    # ═════════════════════════════════════════════════════════════════
+    # IDEMPOTENCY — Re-create should not change anything
+    # ═════════════════════════════════════════════════════════════════
+
+    - name: "IDEMPOTENCY — Re-create BGP probe (should detect existing)"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: bgp_session
+          label: "Test - BGP Monitoring"
+          duration: 300
+          threshold: 40
+        auth_token: "{{ auth.token }}"
+      register: idem_bgp
+
+    - name: Verify idempotency
+      ansible.builtin.assert:
+        that:
+          - idem_bgp.changed == false
+        fail_msg: "Idempotency check failed — probe was recreated"
+
+    # ═════════════════════════════════════════════════════════════════
+    # UPDATE — Modify probe properties
+    # ═════════════════════════════════════════════════════════════════
+
+    - name: "UPDATE — Change BGP probe description"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          label: "Test - BGP Monitoring"
+          description: "Updated by Ansible IBA probe test"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: update_bgp
+
+    - name: Verify update was applied
+      ansible.builtin.assert:
+        that:
+          - update_bgp.changed == true
+          - update_bgp.changes.description is defined
+        fail_msg: "Probe update failed"
+
+    - name: "UPDATE — Disable the Bandwidth probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          label: "Test - Bandwidth Utilization"
+          disabled: true
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: update_bw
+
+    - name: Verify disable was applied
+      ansible.builtin.assert:
+        that:
+          - update_bw.changed == true
+        fail_msg: "Probe disable failed"
+
+    # ═════════════════════════════════════════════════════════════════
+    # DASHBOARD — CRUD tests
+    # ═════════════════════════════════════════════════════════════════
+
+    - name: "DASHBOARD CREATE — Create a test dashboard"
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          label: "Test - Ansible IBA Dashboard"
+          description: "Created by IBA probe test playbook"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: dash_create
+
+    - name: Verify dashboard creation
+      ansible.builtin.assert:
+        that:
+          - dash_create.changed == true
+          - dash_create.id.dashboard is defined
+        fail_msg: "Dashboard creation failed"
+
+    - name: "DASHBOARD UPDATE — Update dashboard description"
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          label: "Test - Ansible IBA Dashboard"
+          description: "Updated by Ansible IBA probe test"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: dash_update
+
+    - name: Verify dashboard update
+      ansible.builtin.assert:
+        that:
+          - dash_update.changed == true
+        fail_msg: "Dashboard update failed"
+
+    - name: "DASHBOARD IDEMPOTENCY — Re-apply same description"
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          label: "Test - Ansible IBA Dashboard"
+          description: "Updated by Ansible IBA probe test"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: dash_idem
+
+    - name: Verify dashboard idempotency
+      ansible.builtin.assert:
+        that:
+          - dash_idem.changed == false
+        fail_msg: "Dashboard idempotency check failed"
+
+    - name: "DASHBOARD DELETE — Remove test dashboard by label"
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          dashboard: "Test - Ansible IBA Dashboard"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: dash_delete
+
+    - name: Verify dashboard deletion
+      ansible.builtin.assert:
+        that:
+          - dash_delete.changed == true
+        fail_msg: "Dashboard deletion by label failed"
+
+    - name: "DASHBOARD RE-CREATE — Recreate for label-based read test"
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          label: "Test - Ansible IBA Dashboard"
+          description: "Recreated for label read test"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: dash_recreate
+
+    - name: "DASHBOARD READ BY LABEL — Fetch dashboard by label"
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          dashboard: "Test - Ansible IBA Dashboard"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: read_dash_label
+
+    - name: Verify dashboard read by label
+      ansible.builtin.assert:
+        that:
+          - read_dash_label.changed == false
+          - read_dash_label.dashboard.label == "Test - Ansible IBA Dashboard"
+          - read_dash_label.dashboard.id == dash_recreate.id.dashboard
+        fail_msg: "Failed to read dashboard by label"
+
+    - name: "DASHBOARD FINAL DELETE — Remove dashboard by ID"
+      juniper.apstra.iba_probes:
+        type: dashboard
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          dashboard: "{{ dash_recreate.id.dashboard }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    # ═════════════════════════════════════════════════════════════════
+    # DELETE — Clean up all test probes
+    # ═════════════════════════════════════════════════════════════════
+
+    - name: "DELETE — Remove BGP probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_bgp.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: del_bgp
+
+    - name: "DELETE BY LABEL — Remove Bandwidth probe by label"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "Test - Bandwidth Utilization"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: del_bw_label
+
+    - name: Verify label-based deletion
+      ansible.builtin.assert:
+        that:
+          - del_bw_label.changed == true
+        fail_msg: "Probe deletion by label failed"
+
+    - name: "DELETE — Remove COPP probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_copp.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove Device Health probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_health.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove Device Telemetry probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_telemetry.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove LAG probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_lag.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove ECMP probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_ecmp.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove ESI probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_esi.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove MAC Monitor probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_mac.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: Verify BGP probe deletion
+      ansible.builtin.assert:
+        that:
+          - del_bgp.changed == true
+        fail_msg: "Probe deletion failed"
+
+    # ═════════════════════════════════════════════════════════════════
+    # VERIFY DELETE — Confirm probes are gone
+    # ═════════════════════════════════════════════════════════════════
+
+    - name: "VERIFY — Re-delete BGP probe (should be idempotent)"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          label: "Test - BGP Monitoring"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: verify_del
+
+    - name: Verify delete idempotency
+      ansible.builtin.assert:
+        that:
+          - verify_del.changed == false
+        fail_msg: "Delete idempotency check failed"
+
+    # ═════════════════════════════════════════════════════════════════
+    # TEARDOWN — Delete the test blueprint
+    # ═════════════════════════════════════════════════════════════════
+
+    - name: "TEARDOWN — Delete test blueprint"
+      juniper.apstra.blueprint:
+        id: "{{ bp.id }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: bp_delete
+
+    - name: Verify blueprint deletion
+      ansible.builtin.assert:
+        that:
+          - bp_delete.changed == true
+        fail_msg: "Blueprint deletion failed"
+
+    # ─── Logout ───────────────────────────────────────────────────────
+    - name: Logout of Apstra
+      juniper.apstra.authenticate:
+        logout: true
+        auth_token: "{{ auth.token }}"
+
+    - name: Test complete
+      ansible.builtin.debug:
+        msg: "All IBA probe CRUD tests passed successfully!"

--- a/ansible_collections/juniper/apstra/tests/iba_probes.yml
+++ b/ansible_collections/juniper/apstra/tests/iba_probes.yml
@@ -230,6 +230,78 @@
         auth_token: "{{ auth.token }}"
       register: probe_mac
 
+    - name: "CREATE — Device Environmental Checks probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: environmental_data
+          label: "Test - Device Environmental Checks"
+        auth_token: "{{ auth.token }}"
+      register: probe_env
+
+    - name: Verify Device Environmental Checks probe creation
+      ansible.builtin.assert:
+        that:
+          - probe_env.changed == true
+          - probe_env.id.probe is defined
+        fail_msg: "Device Environmental Checks probe creation failed"
+
+    - name: "CREATE — Device Traffic probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: traffic
+          label: "Test - Device Traffic"
+        auth_token: "{{ auth.token }}"
+      register: probe_traffic
+
+    - name: Verify Device Traffic probe creation
+      ansible.builtin.assert:
+        that:
+          - probe_traffic.changed == true
+          - probe_traffic.id.probe is defined
+        fail_msg: "Device Traffic probe creation failed"
+
+    - name: "CREATE — Drain Traffic Anomaly probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: drain_node_traffic_anomaly
+          label: "Test - Drain Traffic Anomaly"
+        auth_token: "{{ auth.token }}"
+      register: probe_drain
+
+    - name: Verify Drain Traffic Anomaly probe creation
+      ansible.builtin.assert:
+        that:
+          - probe_drain.changed == true
+          - probe_drain.id.probe is defined
+        fail_msg: "Drain Traffic Anomaly probe creation failed"
+
+    - name: "CREATE — MLAG Imbalance probe"
+      juniper.apstra.iba_probes:
+        type: predefined
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        body:
+          predefined_probe: mlag_imbalance
+          label: "Test - MLAG Imbalance"
+        auth_token: "{{ auth.token }}"
+      register: probe_mlag
+
+    - name: Verify MLAG Imbalance probe creation
+      ansible.builtin.assert:
+        that:
+          - probe_mlag.changed == true
+          - probe_mlag.id.probe is defined
+        fail_msg: "MLAG Imbalance probe creation failed"
+
     - name: Show all created probe IDs
       ansible.builtin.debug:
         msg:
@@ -242,6 +314,10 @@
           - "ECMP: {{ probe_ecmp.id.probe }}"
           - "ESI: {{ probe_esi.id.probe }}"
           - "MAC: {{ probe_mac.id.probe }}"
+          - "Environmental: {{ probe_env.id.probe }}"
+          - "Traffic: {{ probe_traffic.id.probe }}"
+          - "Drain: {{ probe_drain.id.probe }}"
+          - "MLAG: {{ probe_mlag.id.probe }}"
 
     # ═════════════════════════════════════════════════════════════════
     # READ — Verify probes exist by re-fetching
@@ -571,6 +647,42 @@
         id:
           blueprint: "{{ bp.id.blueprint }}"
           probe: "{{ probe_mac.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove Device Environmental Checks probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_env.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove Device Traffic probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_traffic.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove Drain Traffic Anomaly probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_drain.id.probe }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: "DELETE — Remove MLAG Imbalance probe"
+      juniper.apstra.iba_probes:
+        type: probe
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+          probe: "{{ probe_mlag.id.probe }}"
         state: absent
         auth_token: "{{ auth.token }}"
 


### PR DESCRIPTION
Introduce juniper.apstra.iba_probes module for managing Intent-Based Analytics probes, dashboards, and predefined probe instantiation via the Apstra REST API (/blueprints/{id}/probes, /iba/predefined-probes, /iba/dashboards).

New files:
- plugins/module_utils/apstra/iba_probes.py: API helpers for probe and dashboard CRUD operations using raw_request
- plugins/modules/iba_probes.py: Ansible module supporting three resource types (predefined, probe, dashboard) with full create, read, update, delete and idempotency
- tests/iba_probes.yml: End-to-end test playbook that creates its own blueprint, exercises all 9 predefined probe types, tests read/update/idempotency/delete, dashboard CRUD, and tears down the blueprint
- playbooks/IBA_PROBES_README.md: Documentation covering all 48 predefined probe types, API endpoints, and usage examples

Updated files:
- plugins/module_utils/apstra/name_resolution.py: Add resolve_probe_id() and resolve_dashboard_id() to resolve probes and dashboards by label or UUID, following the existing resolver pattern (fast UUID pass-through, exact match, case-insensitive fallback)

The module supports referencing probes and dashboards by label in id.probe / id.dashboard, in addition to UUID. The test playbook validates label-based read, update, and delete operations.