### PR TITLE
fix(resource_group): resolve VRF-scoped group names and handle non-existent resource groups

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -350,6 +350,42 @@ def resolve_security_zone_id(client_factory, blueprint_id, sz_ref):
     )
 
 
+def resolve_resource_group_name(client_factory, blueprint_id, group_name):
+    """Resolve a resource-group name that may contain a security-zone reference.
+
+    Resource-group names for VRF-scoped groups use the format
+    ``sz:<security_zone_id>,<group_suffix>``.
+    Users may specify a security-zone label or VRF name instead of the raw
+    ID.  This function detects the ``sz:`` prefix, resolves the embedded
+    reference via :func:`resolve_security_zone_id`, and returns the
+    canonical group name with the resolved ID.
+
+    If the group name does not start with ``sz:``, it is returned unchanged.
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param blueprint_id: The blueprint UUID.
+    :param group_name: The resource-group name (e.g.
+        ``"sz:VRF1,leaf_loopback_ips"`` or ``"leaf_loopback_ips"``).
+    :return: The group name with any security-zone reference resolved.
+    """
+    if not group_name or not group_name.startswith("sz:"):
+        return group_name
+
+    # Parse "sz:<sz_ref>,<suffix>"
+    remainder = group_name[3:]  # strip "sz:" prefix
+    comma_idx = remainder.find(",")
+    if comma_idx < 0:
+        # Malformed — no comma separator; return as-is and let the API
+        # report the error.
+        return group_name
+
+    sz_ref = remainder[:comma_idx]
+    suffix = remainder[comma_idx + 1 :]
+
+    resolved_sz_id = resolve_security_zone_id(client_factory, blueprint_id, sz_ref)
+    return f"sz:{resolved_sz_id},{suffix}"
+
+
 def resolve_routing_policy_id(client_factory, blueprint_id, rp_ref):
     """Resolve a routing-policy reference (UUID or label) to its node ID.
 

--- a/ansible_collections/juniper/apstra/plugins/modules/resource_group.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/resource_group.py
@@ -17,6 +17,7 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client impor
 )
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
     resolve_pool_ids,
+    resolve_resource_group_name,
 )
 
 DOCUMENTATION = """
@@ -212,6 +213,12 @@ def main():
                 f"Must specify 'group_type' and 'group_name' in id to manage a {leaf_object_type}"
             )
 
+        # Resolve security-zone name in group_name (e.g. "sz:VRF1,leaf_loopback_ips")
+        group_name = resolve_resource_group_name(
+            client_factory, id["blueprint"], group_name
+        )
+        id["group_name"] = group_name
+
         # Get the object
         ra_client = client_factory.get_resource_allocation_client()
         resource_group = ra_client.blueprints[id["blueprint"]].resource_groups[
@@ -246,6 +253,18 @@ def main():
                         result["msg"] = (
                             f"{leaf_object_type} already up to date, no changes needed"
                         )
+            elif body:
+                # Resource group does not exist yet (e.g. VRF-scoped groups
+                # like "sz:<sz_id>,leaf_loopback_ips" are not pre-created).
+                # A PUT will create the assignment.
+                updated_object = resource_group.update(body)
+                result["changed"] = True
+                if updated_object:
+                    result["response"] = updated_object
+                result["changes"] = body
+                result["msg"] = f"{leaf_object_type} created successfully"
+                # Re-read to populate current_object after creation
+                current_object = resource_group.get()
 
             # Return the final object state (avoid re-reading after updates
             # because SDK may return stale cached data; for creates, fetch


### PR DESCRIPTION
…

Two bugs fixed in the resource_group module:

1. Security zone name resolution in group_name: When using group_name like 'sz:VRF1,leaf_loopback_ips', the VRF label was passed raw to the API. The API expects the security zone ID (e.g. 'sz:<node_id>,leaf_loopback_ips'). Added resolve_resource_group_name() to parse the 'sz:' prefix and resolve the embedded name via resolve_security_zone_id().

2. Non-existent resource groups silently skipped: VRF-scoped resource groups don't pre-exist in the blueprint; they are created on first PUT. When resource_group.get() returned None, the module skipped the update and returned changed=false. Added an elif branch to call resource_group.update(body) for creation.