### PR TITLE
ansible-doc(connectivity_template_assignement): fix typo

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
@@ -114,14 +114,15 @@ options:
       - Must contain C(application_point_ids) list of application-point
         references to assign the CT to (when state is present) or unassign
         from (when state is absent).
-      - Each entry may be:
-      - A raw blueprint graph node ID string
-        (e.g. C(G31G9dCSVcDS9PoeYg)).
-      - A colon-separated shorthand string C("<system_label>:<if_name>")
-        (e.g. C("leaf1:ge-0/0/3") or C("leaf1:ae1")) that is resolved
-        to the interface node ID via a QE graph query.
-      - A resolution dict with C(system) and C(if_name) keys that is
-        resolved to the interface node ID via a QE graph query.
+      - |
+        Each entry may be:
+        - A raw blueprint graph node ID string
+          (e.g. C(G31G9dCSVcDS9PoeYg)).
+        - A colon-separated shorthand string C("<system_label>:<if_name>")
+          (e.g. C("leaf1:ge-0/0/3") or C("leaf1:ae1")) that is resolved
+          to the interface node ID via a QE graph query.
+        - A resolution dict with C(system) and C(if_name) keys that is
+          resolved to the interface node ID via a QE graph query.
     type: dict
     required: true
   state:


### PR DESCRIPTION
when use ansible-doc -t module juniper.apstra.connectivity_template_assignment for get doc, we get

ERROR! Unable to retrieve documentation from 'juniper.apstra.connectivity_template_assignment' due to: Expected string in description of body at index 3, got <class 'ansible.parsing.yaml.objects.AnsibleMapping'>. Expected string in description of body at index 3, got <class 'ansible.parsing.yaml.objects.AnsibleMapping'>

coming from list in list (and ansible-doc don't like this or support) description must be only one list