### PR TITLE
Adding Interface to the physical device through Secutiry Zone Module 

### DIFF
--- a/ansible_collections/juniper/apstra/docs/interconnect_gateway_module.rst
+++ b/ansible_collections/juniper/apstra/docs/interconnect_gateway_module.rst
@@ -188,6 +188,8 @@ Parameters
       - ``label`` (string) — Domain name (required for create).
       - ``route_target`` (string) — Interconnect Route Target in ``<asn>:<nn>`` format (required for create).
       - ``esi_mac`` (string) — Optional per-site ESI MAC address.
+      - ``security_zones`` (dict) — DCI Layer-3 (Type-5) settings keyed by VRF label or ID (auto-resolved). Each value is a dict with ``routing_policy_id`` (label or ID, auto-resolved), ``interconnect_route_target`` (string), and ``enabled_for_l3`` (bool). Optional.
+      - ``virtual_networks`` (dict) — VN connection type settings keyed by virtual network label or ID (auto-resolved). Each value is a dict with ``l2`` (bool), ``l3`` (bool), and ``translation_vni`` (integer). Optional.
 
       **For type=gateway:**
 
@@ -537,6 +539,44 @@ Examples
         body:
           label: "dci-domain-2"
         state: absent
+
+    # ---- DCI Layer-3 (Type-5) via security_zones ----
+
+    # Enable L3 DCI on a VRF with a routing policy and route target.
+    # VRF labels and routing policy labels are resolved automatically.
+    - name: Enable L3 DCI on interconnect domain
+      juniper.apstra.interconnect_gateway:
+        type: domain
+        id:
+          blueprint: "my-datacenter-blueprint"
+        body:
+          label: "dci-domain-1"
+          route_target: "65500:100"
+          security_zones:
+            "my-vrf":
+              routing_policy_id: "dci-l3-policy"
+              interconnect_route_target: "65500:200"
+              enabled_for_l3: true
+        state: present
+
+    # ---- VN Connection Type via virtual_networks ----
+
+    # Set L2+L3 connection type and translation VNI for a virtual network.
+    # VN labels are resolved automatically.
+    - name: Set VN connection type with translation VNI
+      juniper.apstra.interconnect_gateway:
+        type: domain
+        id:
+          blueprint: "my-datacenter-blueprint"
+        body:
+          label: "dci-domain-1"
+          route_target: "65500:100"
+          virtual_networks:
+            "my-virtual-network":
+              l2: true
+              l3: true
+              translation_vni: 10100
+        state: present
 
     # ---- Interconnect Domain Gateway (type: gateway) ----
 

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -770,6 +770,105 @@ def resolve_graph_node_id(client_factory, blueprint_id, label_node_id):
 
 
 # ──────────────────────────────────────────────────────────────────
+#  VRF interface pair resolution
+# ──────────────────────────────────────────────────────────────────
+
+
+def resolve_vrf_interface_pair(client_factory, blueprint_id, sz_id, interface_ref):
+    """Resolve a VRF interface reference to its endpoint pair node IDs.
+
+    Given a physical or subinterface name, finds the matching
+    subinterface within the specified security zone and (optionally)
+    the link partner on the other side.
+
+    Supported ``interface_ref`` formats:
+
+    * ``"xe-0/0/3"`` — physical interface name (must be unique in VRF)
+    * ``"xe-0/0/3.100"`` — subinterface name
+    * ``"leaf1:xe-0/0/3"`` — with system label for disambiguation
+
+    Graph traversal::
+
+        physical(if_name) → composed_of → subinterface(ep1)
+        ← sz_instance ← security_zone(sz_id)
+
+    Link partner::
+
+        ep1 → out('link') → link → in_('link') → ep2
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param blueprint_id: The blueprint UUID.
+    :param sz_id: The security-zone node ID.
+    :param interface_ref: Interface reference string.
+    :return: Tuple ``(ep1_id, ep2_id)`` where *ep2_id* may be ``None``
+             if no link partner is found.
+    :raises ValueError: If the interface is not found or ambiguous.
+    """
+    system_label = None
+    if_name = interface_ref
+    if ":" in interface_ref:
+        system_label, if_name = interface_ref.split(":", 1)
+
+    is_sub = "." in if_name
+    phys_name = if_name.rsplit(".", 1)[0] if is_sub else if_name
+
+    # ── Build query: [system→] physical → composed_of → subif → VRF
+    if system_label:
+        q = (
+            f"node('system', label='{system_label}', name='sys')"
+            f".out('hosted_interfaces')"
+            f".node('interface', if_name='{phys_name}', name='phys')"
+        )
+    else:
+        q = f"node('interface', if_name='{phys_name}', name='phys')"
+
+    if is_sub:
+        q += (
+            f".out('composed_of')"
+            f".node('interface', if_name='{if_name}', name='ep1')"
+        )
+    else:
+        q += f".out('composed_of')" f".node('interface', name='ep1')"
+
+    q += (
+        f".in_().node('sz_instance', name='szi')"
+        f".in_().node('security_zone', id='{sz_id}', name='sz')"
+    )
+
+    ep1_results = _run_qe(client_factory, blueprint_id, q)
+    if not ep1_results:
+        raise ValueError(
+            f"Interface '{interface_ref}' not found in security zone "
+            f"'{sz_id}' in blueprint '{blueprint_id}'"
+        )
+    if len(ep1_results) > 1:
+        raise ValueError(
+            f"Ambiguous: '{if_name}' matches {len(ep1_results)} "
+            f"interfaces in the VRF. Use 'system_label:{if_name}' "
+            f"to disambiguate."
+        )
+
+    ep1_id = ep1_results[0]["ep1"]["id"]
+
+    # ── Find link partner (ep2) ──────────────────────────────────
+    ep2_q = (
+        f"node('interface', id='{ep1_id}', name='ep1')"
+        f".out('link').node('link', name='lnk')"
+        f".in_('link').node('interface', name='ep2')"
+    )
+    ep2_results = _run_qe(client_factory, blueprint_id, ep2_q)
+
+    ep2_id = None
+    if ep2_results:
+        for r in ep2_results:
+            if r["ep2"]["id"] != ep1_id:
+                ep2_id = r["ep2"]["id"]
+                break
+
+    return ep1_id, ep2_id
+
+
+# ──────────────────────────────────────────────────────────────────
 #  IBA Probe resolution
 # ──────────────────────────────────────────────────────────────────
 

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -707,6 +707,68 @@ def resolve_application_point_ids(client_factory, blueprint_id, ap_refs):
     ]
 
 
+def resolve_graph_node_id(client_factory, blueprint_id, label_node_id):
+    """Resolve a label-based node reference to its graph node UUID.
+
+    Accepts colon-separated shorthand ``"system_label:if_name"`` and
+    resolves it via a QE graph query.
+
+    Supported formats:
+
+    * ``"system_label:if_name"`` — physical interface
+      (e.g. ``"leaf1:xe-0/0/7"``).
+    * ``"system_label:if_name.subid"`` — subinterface
+      (e.g. ``"leaf1:xe-0/0/7.100"``).  Resolved via
+      ``system → hosted_interfaces → interface(if_name=parent) →
+      composed_of → interface(if_type=subinterface, if_name=full)``.
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param blueprint_id: The blueprint UUID.
+    :param label_node_id: A ``"system_label:if_name"`` string.
+    :return: The resolved graph node UUID string.
+    :raises ValueError: If the reference cannot be resolved.
+    """
+    if not label_node_id or ":" not in str(label_node_id):
+        raise ValueError(
+            f"Label-based node_id must be 'system_label:if_name', "
+            f"got '{label_node_id}'"
+        )
+
+    system_label, if_name = str(label_node_id).split(":", 1)
+
+    if "." in if_name:
+        # Subinterface: system → hosted_interfaces → phys → composed_of → subif
+        query = (
+            f"node('system', label='{system_label}', name='sys')"
+            f".out('hosted_interfaces')"
+            f".node('interface', name='phys')"
+            f".out('composed_of')"
+            f".node('interface', if_type='subinterface', "
+            f"if_name='{if_name}', name='subif')"
+        )
+        items = _run_qe(client_factory, blueprint_id, query)
+        if not items:
+            raise ValueError(
+                f"Subinterface '{if_name}' not found on system "
+                f"'{system_label}' in blueprint '{blueprint_id}'"
+            )
+        return items[0]["subif"]["id"]
+    else:
+        # Physical interface
+        query = (
+            f"node('system', label='{system_label}', name='sys')"
+            f".out('hosted_interfaces')"
+            f".node('interface', if_name='{if_name}', name='intf')"
+        )
+        items = _run_qe(client_factory, blueprint_id, query)
+        if not items:
+            raise ValueError(
+                f"Interface '{if_name}' not found on system "
+                f"'{system_label}' in blueprint '{blueprint_id}'"
+            )
+        return items[0]["intf"]["id"]
+
+
 # ──────────────────────────────────────────────────────────────────
 #  IBA Probe resolution
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -296,22 +296,32 @@ def _run_qe(client_factory, blueprint_id, query_str):
     return run_qe_query(client_factory, blueprint_id, query_str)
 
 
-def resolve_security_zone_id(client_factory, blueprint_id, sz_ref):
-    """Resolve a security-zone reference (UUID or label) to its node ID.
+def resolve_security_zone_id(
+    client_factory, blueprint_id, sz_ref, raise_on_missing=True
+):
+    """Resolve a security-zone reference (UUID, label, or vrf_name) to its node ID.
+
+    Resolution order: exact ID → exact label → case-insensitive label →
+    exact vrf_name → case-insensitive vrf_name.
 
     :param client_factory: An ``ApstraClientFactory`` instance.
     :param blueprint_id: The blueprint UUID.
-    :param sz_ref: The security-zone UUID or label.
-    :return: The resolved security-zone node ID string.
+    :param sz_ref: The security-zone UUID, label, or vrf_name.
+    :param raise_on_missing: If ``True`` (default), raise ``ValueError``
+        when the security zone is not found.  If ``False``, return ``None``.
+    :return: The resolved security-zone node ID string, or ``None`` when
+        *raise_on_missing* is ``False`` and no match is found.
     """
     if not sz_ref or _is_uuid(sz_ref):
         return sz_ref
 
     results = _run_qe(client_factory, blueprint_id, "node('security_zone', name='sz')")
     if not results:
-        raise ValueError(
-            f"Security zone '{sz_ref}' not found — no security zones exist in blueprint."
-        )
+        if raise_on_missing:
+            raise ValueError(
+                f"Security zone '{sz_ref}' not found — no security zones exist in blueprint."
+            )
+        return None
 
     # Exact ID match (Apstra graph node IDs are short strings, not UUIDs)
     for r in results:
@@ -344,10 +354,13 @@ def resolve_security_zone_id(client_factory, blueprint_id, sz_ref):
         if (sz.get("vrf_name") or "").lower() == ref_lower:
             return sz["id"]
 
-    available = [r.get("sz", {}).get("label", "") for r in results]
-    raise ValueError(
-        f"Security zone '{sz_ref}' not found in blueprint. " f"Available: {available}"
-    )
+    if raise_on_missing:
+        available = [r.get("sz", {}).get("label", "") for r in results]
+        raise ValueError(
+            f"Security zone '{sz_ref}' not found in blueprint. "
+            f"Available: {available}"
+        )
+    return None
 
 
 def resolve_resource_group_name(client_factory, blueprint_id, group_name):

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -480,6 +480,7 @@ node:
 
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
     resolve_template_id as _resolve_template_id,
+    resolve_graph_node_id,
 )
 
 
@@ -620,10 +621,68 @@ def _handle_queried(module, client_factory, blueprint_id):
 
 
 def _handle_node_updated(module, client_factory, blueprint_id):
-    """Handle state=node_updated -- single-node or bulk-by-label assignment."""
+    """Handle state=node_updated -- single-node or bulk-by-label assignment.
+
+    Supports three modes:
+      1. ``assignment`` dict -- bulk assign by label
+      2. ``node_id`` + ``node_properties`` -- patch by UUID (top-level params)
+      3. ``body.node_id`` + ``body.node_properties`` -- patch by label
+         (e.g. ``body.node_id: "leaf1:xe-0/0/7.100"``)
+    """
     params = module.params
     node_id = params.get("node_id")
     assignment = params.get("assignment")
+    body = params.get("body")
+
+    # ── Body-based mode (body.node_id + body.node_properties) ─────────
+    if body and "node_id" in body:
+        if node_id or assignment:
+            module.fail_json(
+                msg="body.node_id cannot be used with top-level "
+                "node_id or assignment"
+            )
+        body_node_id = body["node_id"]
+        body_props = body.get("node_properties", {})
+        if not body_props:
+            module.fail_json(
+                msg="body.node_properties is required when using body.node_id"
+            )
+
+        # Resolve label-based node_id (e.g. "leaf1:xe-0/0/7.100") to UUID
+        resolved_id = body_node_id
+        if ":" in body_node_id:
+            try:
+                resolved_id = resolve_graph_node_id(
+                    client_factory, blueprint_id, body_node_id
+                )
+            except ValueError as exc:
+                module.fail_json(msg=str(exc))
+
+        # Read current node, compute diff, patch
+        current = get_node(client_factory, blueprint_id, resolved_id)
+        if current is None:
+            module.fail_json(
+                msg=f"Node '{body_node_id}' (resolved: {resolved_id}) "
+                f"not found in blueprint '{blueprint_id}'"
+            )
+
+        changes = node_needs_update(current, body_props)
+        if not changes:
+            return dict(
+                changed=False,
+                node=current,
+                node_id=resolved_id,
+                msg="node already up to date",
+            )
+
+        patch_node(client_factory, blueprint_id, resolved_id, changes)
+        final = get_node(client_factory, blueprint_id, resolved_id)
+        return dict(
+            changed=True,
+            node=final,
+            node_id=resolved_id,
+            msg=f"node updated: {', '.join(changes.keys())}",
+        )
 
     # ── Bulk assignment mode (assignment dict) ────────────────────────────
     if assignment:

--- a/ansible_collections/juniper/apstra/plugins/modules/configlets.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/configlets.py
@@ -96,7 +96,7 @@ options:
   body:
     description:
       - Dictionary containing the configlet object details.
-      - For catalog configlets, keys include C(display_name), C(ref_archs), and C(generators).
+      - For catalog configlets, keys include C(display_name), C(ref_archs) (optional, defaults to C(["two_stage_l3clos"])), and C(generators).
       - For blueprint configlets, keys include C(label), C(condition), and C(configlet)
         (which itself contains C(display_name) and C(generators)).
       - Each generator is a dictionary with C(config_style), C(template_text),
@@ -509,6 +509,9 @@ def _manage_catalog_configlet(module, client_factory):
         else:
             if body is None:
                 raise ValueError(f"Must specify 'body' to create a {leaf_object_type}")
+            # Default ref_archs when not provided (matches Apstra UI behaviour)
+            if "ref_archs" not in body:
+                body["ref_archs"] = ["two_stage_l3clos"]
             created_object = client_factory.object_request(
                 object_type, "create", id, body
             )

--- a/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
@@ -120,6 +120,15 @@ options:
       - "  C(route_target) (string) - Interconnect Route Target in
         C(<asn>:<nn>) format (required for create)."
       - "  C(esi_mac) (string) - Optional per-site ESI MAC address."
+      - "  C(security_zones) (dict) - DCI Layer-3 (Type-5) settings
+        keyed by VRF label or ID (auto-resolved). Each value is a
+        dict with C(routing_policy_id) (label or ID, auto-resolved),
+        C(interconnect_route_target) (string), and C(enabled_for_l3)
+        (bool). Optional."
+      - "  C(virtual_networks) (dict) - VN connection type settings
+        keyed by virtual network label or ID (auto-resolved). Each
+        value is a dict with C(l2) (bool), C(l3) (bool), and
+        C(translation_vni) (integer). Optional."
       - "For C(type=gateway):"
       - "  C(gw_name) (string) - Gateway name (required for create)."
       - "  C(gw_ip) (string) - Gateway IPv4 address (required for
@@ -216,6 +225,44 @@ EXAMPLES = """
     body:
       label: "dci-domain-2"
     state: absent
+
+# ---- DCI Layer-3 (Type-5) via security_zones ----
+
+# Enable L3 DCI on a VRF with a routing policy and route target.
+# VRF labels and routing policy labels are resolved automatically.
+- name: Enable L3 DCI on interconnect domain
+  juniper.apstra.interconnect_gateway:
+    type: domain
+    id:
+      blueprint: "my-datacenter-blueprint"
+    body:
+      label: "dci-domain-1"
+      route_target: "65500:100"
+      security_zones:
+        "my-vrf":
+          routing_policy_id: "dci-l3-policy"
+          interconnect_route_target: "65500:200"
+          enabled_for_l3: true
+    state: present
+
+# ---- VN Connection Type via virtual_networks ----
+
+# Set L2+L3 connection type and translation VNI for a virtual network.
+# VN labels are resolved automatically.
+- name: Set VN connection type with translation VNI
+  juniper.apstra.interconnect_gateway:
+    type: domain
+    id:
+      blueprint: "my-datacenter-blueprint"
+    body:
+      label: "dci-domain-1"
+      route_target: "65500:100"
+      virtual_networks:
+        "my-virtual-network":
+          l2: true
+          l3: true
+          translation_vni: 10100
+    state: present
 
 # ---- Interconnect Domain Gateway (type: gateway) ----
 

--- a/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
@@ -15,6 +15,15 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client impor
     ApstraClientFactory,
     singular_leaf_object_type,
 )
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_security_zone_id,
+    resolve_vrf_interface_pair,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes import (
+    get_node,
+    patch_node,
+    node_needs_update,
+)
 
 DOCUMENTATION = """
 ---
@@ -174,6 +183,61 @@ msg:
 """
 
 
+def _apply_interface_ip_assignments(
+    client_factory, blueprint_id, sz_id, assignments, result
+):
+    """Patch IP addresses on VRF interface endpoints.
+
+    For each entry in *assignments*, resolves the interface within the
+    security zone, then patches endpoint1 and (optionally) endpoint2
+    with the specified IPv4 address / type.
+
+    :param assignments: List of dicts, each with ``interface``,
+        ``endpoint1_ipv4_address``, etc.
+    :param result: Module result dict — ``changed`` and
+        ``ip_assignments`` are updated in-place.
+    """
+    ip_results = []
+    for assignment in assignments:
+        interface_name = assignment["interface"]
+        ep1_id, ep2_id = resolve_vrf_interface_pair(
+            client_factory, blueprint_id, sz_id, interface_name
+        )
+
+        entry = {"interface": interface_name, "endpoint1_id": ep1_id}
+
+        # ── Patch endpoint1 ──────────────────────────────────────
+        if "endpoint1_ipv4_address" in assignment:
+            ep1_props = {"ipv4_addr": assignment["endpoint1_ipv4_address"]}
+            if "endpoint1_ipv4_type" in assignment:
+                ep1_props["ipv4_type"] = assignment["endpoint1_ipv4_type"]
+            current = get_node(client_factory, blueprint_id, ep1_id)
+            changes = node_needs_update(current, ep1_props)
+            if changes:
+                patch_node(client_factory, blueprint_id, ep1_id, changes)
+                result["changed"] = True
+                entry["endpoint1_changed"] = True
+
+        # ── Patch endpoint2 ──────────────────────────────────────
+        if ep2_id and "endpoint2_ipv4_address" in assignment:
+            ep2_props = {"ipv4_addr": assignment["endpoint2_ipv4_address"]}
+            if "endpoint2_ipv4_type" in assignment:
+                ep2_props["ipv4_type"] = assignment["endpoint2_ipv4_type"]
+            current = get_node(client_factory, blueprint_id, ep2_id)
+            changes = node_needs_update(current, ep2_props)
+            if changes:
+                patch_node(client_factory, blueprint_id, ep2_id, changes)
+                result["changed"] = True
+                entry["endpoint2_changed"] = True
+            entry["endpoint2_id"] = ep2_id
+        elif "endpoint2_ipv4_address" in assignment and not ep2_id:
+            entry["endpoint2_warning"] = "No link partner found"
+
+        ip_results.append(entry)
+
+    result["ip_assignments"] = ip_results
+
+
 def main():
     object_module_args = dict(
         id=dict(type="dict", required=True),
@@ -203,6 +267,14 @@ def main():
         body = module.params.get("body", None)
         state = module.params["state"]
         tags = module.params.get("tags", None)
+
+        # Pop custom fields that the Apstra API does not understand
+        interfaces_ip_assignments = None
+        if body:
+            interfaces_ip_assignments = body.pop("interfaces_ip_assignments", None)
+            sz_name = body.pop("sz_name", None)
+            if sz_name:
+                body.setdefault("label", sz_name)
 
         # Resolve blueprint name to ID if needed
         if "blueprint" in id:
@@ -286,6 +358,16 @@ def main():
             else:
                 result[leaf_object_type] = client_factory.object_request(
                     object_type=object_type, op="get", id=id, retry=10, retry_delay=3
+                )
+
+            # Apply interface IP assignments if specified
+            if interfaces_ip_assignments:
+                _apply_interface_ip_assignments(
+                    client_factory,
+                    id["blueprint"],
+                    id[leaf_object_type],
+                    interfaces_ip_assignments,
+                    result,
                 )
 
         # If we still don't have an id, there's a problem

--- a/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
@@ -270,11 +270,18 @@ def main():
 
         # Pop custom fields that the Apstra API does not understand
         interfaces_ip_assignments = None
+        sz_name = None
         if body:
             interfaces_ip_assignments = body.pop("interfaces_ip_assignments", None)
             sz_name = body.pop("sz_name", None)
             if sz_name:
                 body.setdefault("label", sz_name)
+                # When sz_name is the only source of "label" and no other
+                # creation/update fields were supplied, mark this as a
+                # lookup-only operation so we don't accidentally try to
+                # create a VRF with incomplete data.
+                if set(body.keys()) == {"label"}:
+                    body = None
 
         # Resolve blueprint name to ID if needed
         if "blueprint" in id:
@@ -298,15 +305,22 @@ def main():
 
         # See if the object exists
         current_object = None
+        lookup_label = (body or {}).get("label") or sz_name
         if object_id is None:
-            if (body is not None) and ("label" in body):
+            if lookup_label:
                 id_found = client_factory.get_id_by_label(
-                    id["blueprint"], leaf_object_type, body["label"]
+                    id["blueprint"], leaf_object_type, lookup_label
                 )
                 if id_found:
                     id[leaf_object_type] = id_found
                     current_object = client_factory.object_request(
                         object_type, "get", id
+                    )
+                elif sz_name:
+                    raise ValueError(
+                        f"Security zone '{sz_name}' not found in blueprint "
+                        f"'{id['blueprint']}'. Use 'label', 'sz_type', and "
+                        f"'vrf_name' to create a new routing zone."
                     )
         else:
             current_object = client_factory.object_request(object_type, "get", id)

--- a/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
@@ -308,20 +308,23 @@ def main():
         lookup_label = (body or {}).get("label") or sz_name
         if object_id is None:
             if lookup_label:
-                id_found = client_factory.get_id_by_label(
-                    id["blueprint"], leaf_object_type, lookup_label
+                # All name resolution goes through resolve_security_zone_id
+                # which checks: exact ID → label → case-insensitive label
+                # → vrf_name → case-insensitive vrf_name.
+                # When body is None (lookup-only via sz_name), raise if
+                # not found; otherwise return None so creation can proceed.
+                id_found = resolve_security_zone_id(
+                    client_factory,
+                    id["blueprint"],
+                    lookup_label,
+                    raise_on_missing=(body is None),
                 )
-                if id_found:
-                    id[leaf_object_type] = id_found
-                    current_object = client_factory.object_request(
-                        object_type, "get", id
-                    )
-                elif sz_name:
-                    raise ValueError(
-                        f"Security zone '{sz_name}' not found in blueprint "
-                        f"'{id['blueprint']}'. Use 'label', 'sz_type', and "
-                        f"'vrf_name' to create a new routing zone."
-                    )
+            else:
+                id_found = None
+
+            if id_found:
+                id[leaf_object_type] = id_found
+                current_object = client_factory.object_request(object_type, "get", id)
         else:
             current_object = client_factory.object_request(object_type, "get", id)
 
@@ -397,6 +400,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/tests/interconnect_gateway.yml
+++ b/ansible_collections/juniper/apstra/tests/interconnect_gateway.yml
@@ -727,6 +727,75 @@
         success_msg: "PASSED: L3 DCI is idempotent"
 
     # ==============================================================
+    #  STEP 9b: Simplified L3 DCI — single task with all options
+    # ==============================================================
+    # Instead of separate steps for routing policy creation, payload
+    # building, and L3 DCI enablement, users can combine everything
+    # into a single interconnect_gateway domain task.
+    #
+    # The security_zones field accepts:
+    #   - VRF label or ID as the dict key (auto-resolved)
+    #   - routing_policy_id: routing policy label or ID (auto-resolved)
+    #   - interconnect_route_target: the L3 route target string
+    #   - enabled_for_l3: true to enable Type-5 DCI
+    #
+    # This is equivalent to Steps 8 + 9 combined: the routing policy
+    # must already exist (created in Step 8), but everything else is
+    # handled in one task — no separate set_fact needed.
+
+    - name: "BP0: Simplified L3 DCI — single task with routing policy, route target, and Type-5 enable"
+      juniper.apstra.interconnect_gateway:
+        type: domain
+        id:
+          blueprint: "{{ bp0.id.blueprint }}"
+        body:
+          label: "{{ dci_domain_label }}"
+          route_target: "{{ dci_route_target }}"
+          security_zones: >-
+            {{ { vrf_label: {
+                   'routing_policy_id': routing_policy_label,
+                   'interconnect_route_target': l3_route_target,
+                   'enabled_for_l3': true
+                 }
+            } }}
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: bp0_l3_simple
+
+    - name: "BP1: Simplified L3 DCI — single task with routing policy, route target, and Type-5 enable"
+      juniper.apstra.interconnect_gateway:
+        type: domain
+        id:
+          blueprint: "{{ bp1.id.blueprint }}"
+        body:
+          label: "{{ dci_domain_label }}"
+          route_target: "{{ dci_route_target }}"
+          security_zones: >-
+            {{ { vrf_label: {
+                   'routing_policy_id': routing_policy_label,
+                   'interconnect_route_target': l3_route_target,
+                   'enabled_for_l3': true
+                 }
+            } }}
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: bp1_l3_simple
+
+    - name: Show simplified L3 DCI results
+      ansible.builtin.debug:
+        msg: |
+          BP0 L3 DCI (simplified): changed={{ bp0_l3_simple.changed }}
+          BP1 L3 DCI (simplified): changed={{ bp1_l3_simple.changed }}
+
+    - name: Verify simplified L3 DCI is idempotent (no change since Step 9 already applied)
+      ansible.builtin.assert:
+        that:
+          - not bp0_l3_simple.changed
+          - not bp1_l3_simple.changed
+        fail_msg: "Simplified L3 DCI should be idempotent (same config as Step 9)"
+        success_msg: "PASSED: Simplified single-task L3 DCI is idempotent"
+
+    # ==============================================================
     #  STEP 10: Set VN connection type (L2+L3) and translation VNI
     # ==============================================================
     # Uses virtual_networks body field -> resolved to
@@ -804,6 +873,73 @@
           - not bp0_vn_idem.changed
         fail_msg: "VN connection type should be idempotent"
         success_msg: "PASSED: VN connection type is idempotent"
+
+    # ==============================================================
+    #  STEP 10b: Simplified VN connection type — single task
+    # ==============================================================
+    # Instead of separate steps for payload building and VN connection
+    # type enablement, users can specify virtual_networks directly
+    # in the interconnect_gateway domain task.
+    #
+    # The virtual_networks field accepts:
+    #   - VN label or ID as the dict key (auto-resolved)
+    #   - l2: true/false to enable Layer-2 (EVPN Type 2)
+    #   - l3: true/false to enable Layer-3 (EVPN Type 5)
+    #   - translation_vni: integer VNI for translation
+    #
+    # This eliminates the need for a separate set_fact task.
+
+    - name: "BP0: Simplified VN connection type — single task with L2, L3, and translation VNI"
+      juniper.apstra.interconnect_gateway:
+        type: domain
+        id:
+          blueprint: "{{ bp0.id.blueprint }}"
+        body:
+          label: "{{ dci_domain_label }}"
+          route_target: "{{ dci_route_target }}"
+          virtual_networks: >-
+            {{ { bp0_vn_label: {
+                   'l2': true,
+                   'l3': true,
+                   'translation_vni': bp0_vn_vni | int
+                 }
+            } }}
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: bp0_vn_simple
+
+    - name: "BP1: Simplified VN connection type — single task with L2, L3, and translation VNI"
+      juniper.apstra.interconnect_gateway:
+        type: domain
+        id:
+          blueprint: "{{ bp1.id.blueprint }}"
+        body:
+          label: "{{ dci_domain_label }}"
+          route_target: "{{ dci_route_target }}"
+          virtual_networks: >-
+            {{ { bp1_vn_label: {
+                   'l2': true,
+                   'l3': true,
+                   'translation_vni': bp1_vn_vni | int
+                 }
+            } }}
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: bp1_vn_simple
+
+    - name: Show simplified VN connection type results
+      ansible.builtin.debug:
+        msg: |
+          BP0 VN DCI (simplified): changed={{ bp0_vn_simple.changed }}
+          BP1 VN DCI (simplified): changed={{ bp1_vn_simple.changed }}
+
+    - name: Verify simplified VN connection type is idempotent (no change since Step 10 already applied)
+      ansible.builtin.assert:
+        that:
+          - not bp0_vn_simple.changed
+          - not bp1_vn_simple.changed
+        fail_msg: "Simplified VN connection type should be idempotent (same config as Step 10)"
+        success_msg: "PASSED: Simplified single-task VN connection type is idempotent"
 
     # ==============================================================
     #  DCI Setup Summary


### PR DESCRIPTION
- A simplified single-task VN connection type approach, mirroring what Step 9b does for L3 DCI. Instead of building the payload via set_fact then passing it, users can specify virtual_networks inline

- A simplified single-task approach that combines routing policy attachment, interconnect route target, and Type-5 enablement into one interconnect_gateway domain call