### PR TITLE
Add vim_ip shorthand and vlan_remediation_policy support to virtual_i…

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -1304,3 +1304,51 @@ def resolve_virtual_infra_manager_id(client_factory, vim_ref):
     raise ValueError(
         f"Virtual Infra Manager '{vim_ref}' not found. Available: {available}"
     )
+
+
+def resolve_vim_agent_and_system_id(client_factory, vim_ip):
+    """Look up a VIM by management IP and return (agent_id, system_id).
+
+    Searches ``GET /virtual-infra-managers`` for a VIM whose
+    ``management_ip`` matches *vim_ip*.  Returns the VIM's ``id``
+    (used as ``agent_id`` in the blueprint assignment) and its
+    ``system_id`` (populated after the VIM connects to vCenter).
+
+    Raises ``ValueError`` when:
+    - No VIM has the given management IP.
+    - The VIM is found but has no ``system_id`` yet (i.e. it has not yet
+      connected to vCenter — retry after the VIM reaches
+      ``connection_state: connected``).
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param vim_ip:         Management IP of the VIM (e.g. ``"10.0.0.100"``).
+    :returns:              Tuple ``(agent_id, system_id)`` — both strings.
+    """
+    base = client_factory.get_base_client()
+    result = base.virtual_infra_managers.list()
+    if result is None:
+        all_vims = []
+    elif isinstance(result, list):
+        all_vims = result
+    elif isinstance(result, dict) and "items" in result:
+        all_vims = result["items"]
+    else:
+        all_vims = []
+
+    for vim in all_vims:
+        if vim.get("management_ip") == vim_ip:
+            agent_id = vim.get("id")
+            system_id = vim.get("system_id") or vim.get("vcenter_info", {}).get("system_id", "")
+            if not system_id:
+                raise ValueError(
+                    f"VIM with management_ip '{vim_ip}' found (id={agent_id}) "
+                    "but has no system_id yet — the VIM may not have connected "
+                    "to vCenter. Check connection_state and retry."
+                )
+            return agent_id, system_id
+
+    available = [vim.get("management_ip", "") for vim in all_vims if vim.get("management_ip")]
+    raise ValueError(
+        f"No VIM found with management_ip '{vim_ip}'. "
+        f"Available management IPs: {available}"
+    )

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -1338,7 +1338,7 @@ def resolve_vim_agent_and_system_id(client_factory, vim_ip):
     for vim in all_vims:
         if vim.get("management_ip") == vim_ip:
             agent_id = vim.get("id")
-            system_id = vim.get("system_id") or vim.get("vcenter_info", {}).get("system_id", "")
+            system_id = vim.get("system_id") or ""
             if not system_id:
                 raise ValueError(
                     f"VIM with management_ip '{vim_ip}' found (id={agent_id}) "

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -29,6 +29,7 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query imp
 )
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes import (
     get_node,
+    list_nodes,
     patch_node,
     node_needs_update,
     assign_nodes_by_label,
@@ -249,6 +250,15 @@ options:
       - Only used when C(state=node_updated).
     type: str
     required: false
+  current_label:
+    description:
+      - Current label (display name) of the node to update.
+      - Used as an alternative to C(node_id) — the module resolves the label
+        to a node UUID automatically.
+      - Mutually exclusive with C(node_id).
+      - Only used when C(state=node_updated).
+    type: str
+    required: false
   node_label:
     description:
       - Label to set on the node.
@@ -389,6 +399,16 @@ EXAMPLES = """
     node_id: "{{ srx_intf_id }}"
     node_properties:
       if_name: ge-0/0/0
+    state: node_updated
+
+# Update device name and hostname by current label (no node_id needed)
+- name: Rename leaf1 and update its hostname
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    current_label: "leaf1"
+    node_label: "leaf1-new"
+    hostname: "leaf1-new.example.com"
     state: node_updated
 """
 
@@ -705,10 +725,25 @@ def _handle_node_updated(module, client_factory, blueprint_id):
         result["msg"] = f"{n} node(s) updated, {u} already up to date"
         return result
 
+    # ── Resolve current_label → node_id ────────────────────────────────────
+    current_label = params.get("current_label")
+    if current_label and not node_id:
+        all_nodes = list_nodes(client_factory, blueprint_id)
+        matched_id = next(
+            (nid for nid, nprops in all_nodes.items()
+             if nprops.get("label") == current_label),
+            None,
+        )
+        if matched_id is None:
+            module.fail_json(
+                msg=f"No node with label '{current_label}' found in blueprint '{blueprint_id}'"
+            )
+        node_id = matched_id
+
     # ── Single-node mode (node_id) ────────────────────────────────────────
     if not node_id:
         module.fail_json(
-            msg="Either node_id or assignment is required when state=node_updated"
+            msg="Either node_id, current_label, or assignment is required when state=node_updated"
         )
 
     # Read current node state
@@ -817,6 +852,7 @@ def main():
             required=False,
             choices=["deploy", "undeploy", "drain", "ready"],
         ),
+        current_label=dict(type="str", required=False),
         hostname=dict(type="str", required=False),
         node_label=dict(type="str", required=False),
         node_properties=dict(type="dict", required=False),
@@ -833,6 +869,7 @@ def main():
         mutually_exclusive=[
             ("query", "query_type"),
             ("node_id", "assignment"),
+            ("node_id", "current_label"),
         ],
     )
 

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
@@ -931,7 +931,7 @@ def main():
                 )
             else:
                 ep_client.blueprints[blueprint_id].endpoint_policies[ct_id].patch(
-                    {"label": new_name}
+                    {"label": new_name, "attributes": {}}
                 )
                 result["changed"] = True
                 result["ct_id"] = ct_id

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
@@ -173,6 +173,15 @@ options:
             C(dynamic_bgp_peerings), C(routing_zone_constraints)."
         required: false
         type: dict
+      new_name:
+        description:
+          - Rename the Connectivity Template identified by C(body.name)
+            (or C(id.ct_id)) to this new name.
+          - When provided, only the rename is performed — C(primitives)
+            and C(type) are B(not) required.
+          - The CT must already exist.  Raises an error if not found.
+        required: false
+        type: str
   state:
     description:
       - Desired state of the Connectivity Template.
@@ -183,6 +192,30 @@ options:
 """
 
 EXAMPLES = """
+# ── Rename a Connectivity Template ───────────────────────────────────────────
+# Works for auto-created CTs ("Untagged VxLAN '<VN_NAME>'" etc.) and any
+# user-created CT.  Only body.name (current name) and body.new_name are needed.
+# primitives and type are NOT required for a rename-only operation.
+
+- name: Rename auto-created CT to a friendly name
+  juniper.apstra.connectivity_template:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    body:
+      name: "Untagged VxLAN 'my-vnet'"
+      new_name: "VN-CT"
+    state: present
+
+# Can also use ct_id to find the CT instead of its current name:
+- name: Rename CT by ID
+  juniper.apstra.connectivity_template:
+    id:
+      blueprint: "{{ blueprint_id }}"
+      ct_id: "{{ ct_id }}"
+    body:
+      new_name: "VN-CT"
+    state: present
+
 # ── Interface CT type examples ────────────────────────────────────────
 
 # Interface CT: IP Link + BGP Peering + Routing Policy (full nesting)
@@ -865,6 +898,7 @@ def main():
         id_param["blueprint"] = blueprint_id
         ct_id = id_param.get("ct_id")
         name = body.get("name")
+        new_name = body.get("new_name")
         ct_type = body.get("type")
         description = body.get("description", "") or ""
         tags = body.get("tags") or []
@@ -880,6 +914,33 @@ def main():
                 current_parsed = None
         elif name:
             ct_id, current_parsed = _find_ct_by_name(ep_client, blueprint_id, name)
+
+        # ── RENAME path (new_name present, no primitives needed) ─────
+        if new_name:
+            if not ct_id:
+                raise ValueError(
+                    f"Cannot rename: Connectivity Template "
+                    f"{repr(name) if name else '(ct_id not provided)'} not found."
+                )
+            current_label = (current_parsed or {}).get("name", "")
+            if current_label == new_name:
+                result["changed"] = False
+                result["ct_id"] = ct_id
+                result["msg"] = (
+                    f"connectivity_template already named '{new_name}', no change"
+                )
+            else:
+                ep_client.blueprints[blueprint_id].endpoint_policies[ct_id].patch(
+                    {"label": new_name}
+                )
+                result["changed"] = True
+                result["ct_id"] = ct_id
+                result["msg"] = (
+                    f"connectivity_template renamed "
+                    f"from '{current_label}' to '{new_name}'"
+                )
+            module.exit_json(**result)
+            return
 
         # ── STATE: present ────────────────────────────────────────────
         if state == "present":

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
@@ -18,6 +18,7 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client impor
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
     resolve_virtual_infra_manager_id,
     resolve_vim_agent_and_system_id,
+    resolve_security_zone_id,
 )
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.vim_vcenter import (
     list_vim_vcenters,
@@ -746,6 +747,14 @@ def _handle_blueprint_vim(module, client_factory, id, body, state, result):
             "agent_id": agent_id,
             "system_id": system_id,
         }
+
+    # ── vnet_remediation_policy: resolve security_zone_id name → UUID ──
+    vrp = body.get("vnet_remediation_policy") if body else None
+    if vrp and vrp.get("security_zone_id"):
+        blueprint_id_for_sz = id.get("blueprint")
+        vrp["security_zone_id"] = resolve_security_zone_id(
+            client_factory, blueprint_id_for_sz, vrp["security_zone_id"]
+        )
 
     object_id = id.get(leaf_object_type)
     collection_id = {k: v for k, v in id.items() if k != leaf_object_type}

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
@@ -17,6 +17,7 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client impor
 )
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
     resolve_virtual_infra_manager_id,
+    resolve_vim_agent_and_system_id,
 )
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.vim_vcenter import (
     list_vim_vcenters,
@@ -131,6 +132,17 @@ options:
         top-level C(system_id) field after the VIM connects to vCenter.
         Both C(agent_id) and C(system_id) are required when creating a
         blueprint virtual_infra entry.
+      - B(Shorthand) — instead of specifying C(agent_id) and C(system_id)
+        manually, provide C(vim_ip) (the VIM's management IP address) and
+        the module will look up the matching VIM automatically, resolving
+        both C(agent_id) and C(system_id) from the global VIM list.
+        Requires the VIM to be already connected to vCenter (so that
+        C(system_id) is populated).
+      - B(VLAN Remediation Policy) — when creating or updating a blueprint
+        virtual_infra node, include C(vlan_remediation_policy) (str) in
+        the body to set the VLAN remediation behaviour.  Accepted values
+        depend on the Apstra version; common values are C(drop) (default)
+        and C(remediate).  This field is passed through to the API as-is.
     type: dict
     required: false
   scope:
@@ -338,7 +350,8 @@ EXAMPLES = """
 
 # ── Blueprint scope: assign VIM node to a blueprint ──────────────
 
-- name: Add virtual infra node to blueprint
+# Option A — explicit agent_id + system_id
+- name: Add virtual infra node to blueprint (explicit IDs)
   # agent_id = VIM UUID (id.virtual_infra_manager from the global VIM create)
   # system_id = VIM's own system_id field (returned after VIM connects to vCenter)
   # Both are REQUIRED by the Apstra API when creating a blueprint virtual_infra entry.
@@ -349,6 +362,30 @@ EXAMPLES = """
       infra_type: "vcenter"
       agent_id: "{{ vim_result.id.virtual_infra_manager }}"
       system_id: "{{ vim_result.virtual_infra_manager.system_id }}"
+    state: present
+  register: bp_vim
+
+# Option B — shorthand via vim_ip (auto-resolves agent_id + system_id)
+- name: Add virtual infra node to blueprint (by VIM IP — simpler)
+  juniper.apstra.virtual_infra_manager:
+    id:
+      blueprint: "prod-dc1"
+    body:
+      infra_type: "vcenter"
+      vim_ip: "10.0.0.100"   # management IP of the VIM — agent_id/system_id resolved automatically
+    state: present
+  register: bp_vim
+
+# ── Blueprint scope: assign VIM with VLAN Remediation Policy ──────
+
+- name: Add VIM to blueprint with VLAN remediation policy
+  juniper.apstra.virtual_infra_manager:
+    id:
+      blueprint: "prod-dc1"
+    body:
+      infra_type: "vcenter"
+      vim_ip: "10.0.0.100"
+      vlan_remediation_policy: "remediate"   # or "drop" (default)
     state: present
   register: bp_vim
 
@@ -475,6 +512,12 @@ msg:
   description: Human-readable status message.
   type: str
   returned: always
+resolved_from_vim_ip:
+  description: >-
+    When C(body.vim_ip) is used, contains the resolved C(vim_ip),
+    C(agent_id), and C(system_id) that were substituted into the request.
+  type: dict
+  returned: when body.vim_ip is provided (blueprint scope)
 """
 
 
@@ -691,6 +734,18 @@ def _handle_blueprint_vim(module, client_factory, id, body, state, result):
     """Handle blueprint-level VIM CRUD at /api/blueprints/{id}/virtual_infra."""
     object_type = "blueprints.virtual_infra"
     leaf_object_type = singular_leaf_object_type(object_type)  # "virtual_infra"
+
+    # ── vim_ip shorthand: resolve management IP → agent_id + system_id ──
+    if body and body.get("vim_ip"):
+        vim_ip = body.pop("vim_ip")
+        agent_id, system_id = resolve_vim_agent_and_system_id(client_factory, vim_ip)
+        body.setdefault("agent_id", agent_id)
+        body.setdefault("system_id", system_id)
+        result["resolved_from_vim_ip"] = {
+            "vim_ip": vim_ip,
+            "agent_id": agent_id,
+            "system_id": system_id,
+        }
 
     object_id = id.get(leaf_object_type)
     collection_id = {k: v for k, v in id.items() if k != leaf_object_type}


### PR DESCRIPTION
…nfra_manager

Enhancement 1 — vim_ip shorthand (blueprint scope):
  Instead of manually specifying agent_id + system_id, users can now
  provide body.vim_ip (the VIM's management IP). The module looks up
  the matching global VIM, extracts its id (agent_id) and system_id,
  and substitutes them into the body before sending to the API.
  Returns resolved_from_vim_ip in the result for visibility.
  Raises a clear error if no VIM matches the IP, or if the VIM has
  not yet connected (system_id empty).

Enhancement 2 — vlan_remediation_policy (blueprint scope):
  The blueprint virtual_infra body is passed through as-is, so
  vlan_remediation_policy and any other valid API fields already work.
  Added documentation (DOCUMENTATION, EXAMPLES) and RETURN entry.

Files changed:
  - name_resolution.py: add resolve_vim_agent_and_system_id()
  - virtual_infra_manager.py: import + use the new resolver, update DOCUMENTATION body section, EXAMPLES (vim_ip + vlan_remediation_policy), RETURN (resolved_from_vim_ip)