### PR TITLE
Add commit_description to blueprint module (state=committed)

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/client.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/client.py
@@ -942,7 +942,7 @@ class ApstraClientFactory:
         tag = tags_client.blueprints[id].tags.get(label=_blueprint_lock_tag_name(id))
         return tag is not None
 
-    def commit_blueprint(self, id, timeout=DEFAULT_BLUEPRINT_COMMIT_TIMEOUT):
+    def commit_blueprint(self, id, timeout=DEFAULT_BLUEPRINT_COMMIT_TIMEOUT, description=None):
         """
         Commit the blueprint with the given ID.
 
@@ -955,6 +955,7 @@ class ApstraClientFactory:
         meaningful indicator of a clean blueprint on every version.
 
         :param id: The ID of the blueprint to commit.
+        :param description: Optional commit description shown in revision history.
         """
         import time
 
@@ -991,8 +992,11 @@ class ApstraClientFactory:
                     raise RuntimeError("Blueprint version is still 0")
 
                 # ---- Phase 2: deploy ----
+                deploy_payload = {"version": bp_version}
+                if description:
+                    deploy_payload["description"] = description
                 deploy_response = blueprint.deploy(
-                    {"version": bp_version}, params={"async": "full"}
+                    deploy_payload, params={"async": "full"}
                 )
                 task_id = deploy_response["task_id"]
 

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -120,6 +120,13 @@ options:
     required: false
     type: int
     default: 30
+  commit_description:
+    description:
+      - Optional description for the commit, visible in the Apstra
+        revision history (same as the C(Description) field in the Web UI).
+      - Only used when C(state=committed).
+    required: false
+    type: str
   state:
     description:
       - The desired state of the blueprint.
@@ -305,6 +312,15 @@ EXAMPLES = """
     id:
       blueprint: "{{ bp.id.blueprint }}"
     lock_state: ignore
+    state: committed
+
+# Commit with a description (visible in revision history)
+- name: Deploy blueprint with description
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ bp.id.blueprint }}"
+    lock_state: ignore
+    commit_description: "Push spine/leaf IP addressing changes"
     state: committed
 
 # Delete a blueprint
@@ -816,6 +832,7 @@ def main():
         commit_timeout=dict(
             type="int", required=False, default=DEFAULT_BLUEPRINT_COMMIT_TIMEOUT
         ),
+        commit_description=dict(type="str", required=False),
         unlock=dict(type="bool", required=False, default=False),
         state=dict(
             type="str",
@@ -974,7 +991,10 @@ def main():
 
         if state == "committed":
             # Commit the blueprint
-            committed = client_factory.commit_blueprint(blueprint_id, commit_timeout)
+            commit_description = module.params.get("commit_description")
+            committed = client_factory.commit_blueprint(
+                blueprint_id, commit_timeout, description=commit_description
+            )
             result["changed"] = committed
             result["msg"] = "blueprint committed successfully"
 


### PR DESCRIPTION
Allows setting a description on a deploy, visible in the Apstra revision history — same as the Description field in the Web UI.

  - name: Deploy with description juniper.apstra.blueprint: id: blueprint: my-bp commit_description: 'Push spine/leaf IP addressing changes' state: committed