### PR TITLE
Add ansible module to manage floating ip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,8 +152,8 @@ install: build
 	test-iba_probes \
 	test-interconnect_gateway \
 	test-cabling_map \
-	test-virtual_infra_manager
-
+        test-virtual_infra_manager \
+        test-floating_ip
 # Ignore warnings about localhost from ansible-playbook
 export ANSIBLE_LOCALHOST_WARNING=False
 export ANSIBLE_INVENTORY_UNPARSED_WARNING=False
@@ -253,6 +253,9 @@ test-cabling_map: install
 test-virtual_infra_manager: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/virtual_infra_manager.yml
 
+test-floating_ip: install
+	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/floating_ip.yml
+
 test-interconnect_gateway: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/interconnect_gateway.yml
 
@@ -339,7 +342,7 @@ delete-connectorops-blueprint: install
 		-e @$(APSTRA_COLLECTION_ROOT)/tests/vars/connectorops_blueprint.yml \
 		-e testbed_file=$(TESTBED_FILE)
 
-test: test-apstra_facts test-blueprint test-virtual_network test-routing_policy test-security_zone test-endpoint_policy test-tag test-resource_group test-configlets test-property_set test-resource_pools test-external_gateway test-connectivity_template test-generic_systems test-system_agents test-os_upgrade test-upgrade_group test-interface_map test-fabric_settings test-interconnect_gateway test-ztp_device test-cabling_map test-iba_probes test-virtual_infra_manager
+test: test-apstra_facts test-blueprint test-virtual_network test-routing_policy test-security_zone test-endpoint_policy test-tag test-resource_group test-configlets test-property_set test-resource_pools test-external_gateway test-connectivity_template test-generic_systems test-system_agents test-os_upgrade test-upgrade_group test-interface_map test-fabric_settings test-interconnect_gateway test-ztp_device test-cabling_map test-iba_probes test-virtual_infra_manager test-floating_ip
 
 # Integration Tests
 .PHONY: test-integration-property_set

--- a/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
@@ -16,6 +16,9 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client impor
     ApstraClientFactory,
     apstra_client_module_args,
 )
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_virtual_network_id,
+)
 
 DOCUMENTATION = """
 ---
@@ -49,6 +52,9 @@ options:
       - C(description) (str) — free-text description.
       - C(ipv4_addr) (str) — IPv4 address in CIDR format (e.g. C(10.2.22.201/24)).
       - C(ipv6_addr) (str) — IPv6 address in CIDR format.
+      - C(virtual_network) (str) — Virtual network name or UUID. Used as a lookup
+        key to find the floating IP that belongs to that VN. Particularly useful for
+        auto-created floating IPs which have no label.
       - C(virtual_network_id) (str) — UUID of the associated virtual network (create only).
       - C(vn_endpoints) (list) — list of VN endpoint IDs (create only).
       - C(generic_system_ids) (list) — list of generic system IDs (create only).
@@ -123,6 +129,18 @@ EXAMPLES = """
     body:
       label: "Tenant5-VIP"          # used to FIND the floating IP
       ipv4_addr: "10.2.22.210/24"   # new address to set via PATCH
+    state: present
+
+# PATCH by VN name — finds the floating IP that belongs to a virtual network.
+# Auto-created floating IPs have no label; use virtual_network to locate them.
+- name: Name an auto-created floating IP by its VN (PATCH)
+  juniper.apstra.floating_ip:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      virtual_network: "Tenant2-VLAN22"   # VN name or UUID — used to FIND the floating IP
+      label: "Tenant2-VIP"                # new label to set via PATCH
+      description: "Auto-created VIP for Tenant2"
     state: present
 
 # PATCH by IPv4 address — useful when label is unknown
@@ -214,6 +232,14 @@ def _find_by_ipv4(all_fips, ipv4_addr):
     return None
 
 
+def _find_by_vn_id(all_fips, vn_id):
+    """Return the first floating IP dict whose virtual_network_id matches."""
+    for fip in all_fips:
+        if fip.get("virtual_network_id") == vn_id:
+            return fip
+    return None
+
+
 def _needs_update(current, desired):
     """Return dict of fields that differ between current and desired."""
     changes = {}
@@ -282,12 +308,18 @@ def main():
             all_fips = _list_all(bp)
             label = body.get("label")
             ipv4_addr = body.get("ipv4_addr")
+            virtual_network = body.pop("virtual_network", None)
 
-            # Try label first, then ipv4_addr as fallback lookup key
+            # Try label first, then ipv4_addr, then virtual_network as lookup keys
             if label:
                 current_fip = _find_by_label(all_fips, label)
             if current_fip is None and ipv4_addr:
                 current_fip = _find_by_ipv4(all_fips, ipv4_addr)
+            if current_fip is None and virtual_network:
+                vn_id = resolve_virtual_network_id(
+                    client_factory, blueprint_id, virtual_network
+                )
+                current_fip = _find_by_vn_id(all_fips, vn_id)
 
             if current_fip is None:
                 if state == "absent":

--- a/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
@@ -88,36 +88,61 @@ EXAMPLES = """
     state: queried
   register: fip
 
-# Give a name to an auto-created floating IP (found by IP address)
-- name: Name the floating IP 10.2.22.201/24
+# Create a new floating IP (POST)
+- name: Create a floating IP
   juniper.apstra.floating_ip:
     id:
       blueprint: "my-blueprint"
     body:
-      ipv4_addr: "10.2.22.201/24"   # used to find the floating IP
       label: "Tenant5-VIP"
       description: "Primary VIP for Tenant5"
+      ipv4_addr: "10.2.22.201/24"
+    state: present
+  register: fip_create
+
+# --- PATCH (update) examples ---
+# The module detects whether the floating IP already exists.
+# If it does, it issues a PATCH with only the changed fields.
+
+# PATCH by node ID — most explicit; supply id.floating_ip directly
+- name: Update floating IP label by node ID (PATCH)
+  juniper.apstra.floating_ip:
+    id:
+      blueprint: "my-blueprint"
+      floating_ip: "{{ fip_node_id }}"
+    body:
+      label: "Tenant5-VIP-renamed"
+      description: "Updated description"
     state: present
 
-# Change IP address of a named floating IP
-- name: Update floating IP address
+# PATCH by label — module looks up the node ID first, then PATCHes
+- name: Update floating IP address by label lookup (PATCH)
   juniper.apstra.floating_ip:
     id:
       blueprint: "my-blueprint"
     body:
-      label: "Tenant5-VIP"          # used to find the floating IP
-      ipv4_addr: "10.2.22.210/24"   # new address
+      label: "Tenant5-VIP"          # used to FIND the floating IP
+      ipv4_addr: "10.2.22.210/24"   # new address to set via PATCH
     state: present
 
-# Update by node ID directly
-- name: Update floating IP by node ID
+# PATCH by IPv4 address — useful when label is unknown
+- name: Update floating IP description by ipv4_addr lookup (PATCH)
+  juniper.apstra.floating_ip:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      ipv4_addr: "10.2.22.201/24"   # used to FIND the floating IP
+      description: "Found by IP"    # new description to set via PATCH
+    state: present
+
+# Idempotent update — no change if values already match
+- name: Ensure floating IP has expected label (idempotent PATCH)
   juniper.apstra.floating_ip:
     id:
       blueprint: "my-blueprint"
       floating_ip: "{{ fip_node_id }}"
     body:
       label: "Tenant5-VIP"
-      ipv4_addr: "10.2.22.201/24"
     state: present
 
 # Delete a floating IP by label

--- a/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import traceback
+import uuid
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
@@ -21,13 +22,13 @@ DOCUMENTATION = """
 module: floating_ip
 short_description: Manage Floating IPs in an Apstra blueprint
 description:
-  - Update, query, or delete Floating IP addresses within an Apstra blueprint.
+  - Create, update, query, or delete Floating IP addresses within an Apstra blueprint.
   - Floating IPs (VIP endpoints) are typically auto-created by Apstra when
-    Connectivity Templates assign them.  This module allows renaming them
-    (C(label)), setting a C(description), and changing the IP address
-    (C(ipv4_addr) / C(ipv6_addr)).
+    Connectivity Templates assign them.  This module also allows creating them
+    manually, renaming them (C(label)), setting a C(description), and changing
+    the IP address (C(ipv4_addr) / C(ipv6_addr)).
   - Use C(state=queried) to list all floating IPs or retrieve a single one.
-  - Use C(state=present) to update an existing floating IP.
+  - Use C(state=present) to create or update a floating IP (idempotent).
   - Use C(state=absent) to delete a floating IP.
 version_added: "0.1.0"
 author: "Juniper Networks"
@@ -38,6 +39,7 @@ options:
       - C(blueprint) (str, required) — blueprint name or UUID.
       - C(floating_ip) (str, optional) — floating IP node UUID.
         If omitted, the module searches by C(body.label) or C(body.ipv4_addr).
+        For creation, a UUID is auto-generated when no existing floating IP is found.
     type: dict
     required: true
   body:
@@ -47,12 +49,15 @@ options:
       - C(description) (str) — free-text description.
       - C(ipv4_addr) (str) — IPv4 address in CIDR format (e.g. C(10.2.22.201/24)).
       - C(ipv6_addr) (str) — IPv6 address in CIDR format.
+      - C(virtual_network_id) (str) — UUID of the associated virtual network (create only).
+      - C(vn_endpoints) (list) — list of VN endpoint IDs (create only).
+      - C(generic_system_ids) (list) — list of generic system IDs (create only).
       - When C(state=present), only supplied fields are changed.
     type: dict
     required: false
   state:
     description:
-      - C(present) — update the floating IP (idempotent).
+      - C(present) — create or update the floating IP (idempotent).
       - C(absent) — delete the floating IP.
       - C(queried) — list all floating IPs or retrieve a single one (read-only).
     type: str
@@ -247,6 +252,7 @@ def main():
 
         # ── Resolve node_id from body if not provided ────────────────────
         current_fip = None
+        create_mode = False
         if not node_id:
             all_fips = _list_all(bp)
             label = body.get("label")
@@ -259,13 +265,17 @@ def main():
                 current_fip = _find_by_ipv4(all_fips, ipv4_addr)
 
             if current_fip is None:
-                lookup = repr(label) if label else repr(ipv4_addr)
-                raise ValueError(
-                    f"No floating IP found matching {lookup} "
-                    f"in blueprint '{blueprint_id}'. "
-                    "Provide id.floating_ip (node UUID) or body.label / body.ipv4_addr."
-                )
-            node_id = current_fip["id"]
+                if state == "absent":
+                    # Nothing to delete
+                    result["changed"] = False
+                    result["msg"] = "floating_ip not found, nothing to delete"
+                    module.exit_json(**result)
+                    return
+                # state=present + not found → create
+                create_mode = True
+                node_id = str(uuid.uuid4())
+            else:
+                node_id = current_fip["id"]
         else:
             # Fetch current state by node_id from experience/web (includes id + immutable)
             all_fips = _list_all(bp)
@@ -274,9 +284,14 @@ def main():
                     current_fip = fip
                     break
             if current_fip is None:
-                raise ValueError(
-                    f"Floating IP node '{node_id}' not found in blueprint '{blueprint_id}'"
-                )
+                if state == "absent":
+                    result["changed"] = False
+                    result["msg"] = (
+                        f"floating_ip '{node_id}' not found, nothing to delete"
+                    )
+                    module.exit_json(**result)
+                    return
+                create_mode = True
 
         result["id"] = {"blueprint": blueprint_id, "floating_ip": node_id}
 
@@ -288,8 +303,32 @@ def main():
             module.exit_json(**result)
             return
 
-        # ── state=present ────────────────────────────────────────────────
-        # Build the patch payload — only fields explicitly in body
+        # ── state=present / create ────────────────────────────────────────
+        if create_mode:
+            create_fields = (
+                "label",
+                "description",
+                "virtual_network_id",
+                "vn_endpoints",
+                "ipv4_addr",
+                "ipv6_addr",
+                "generic_system_ids",
+            )
+            create_payload = {"id": node_id, "immutable": False}
+            for field in create_fields:
+                if field in body:
+                    create_payload[field] = body[field]
+            create_result = bp.floating_ips.create(create_payload)
+            # Fetch the created floating IP
+            created = bp.floating_ips[node_id].get() or {}
+            created["id"] = node_id
+            result["changed"] = True
+            result["floating_ip"] = created
+            result["msg"] = f"floating_ip '{node_id}' created"
+            module.exit_json(**result)
+            return
+
+        # ── state=present / update ────────────────────────────────────────
         patchable = {}
         for field in ("label", "description", "ipv4_addr", "ipv6_addr"):
             if field in body:
@@ -319,9 +358,7 @@ def main():
         # Merge id back in (get() response doesn't include it)
         updated["id"] = node_id
         result["floating_ip"] = updated
-        result["msg"] = (
-            f"floating_ip '{node_id}' updated: {', '.join(changes.keys())}"
-        )
+        result["msg"] = f"floating_ip '{node_id}' updated: {', '.join(changes.keys())}"
 
     except Exception as e:
         tb = traceback.format_exc()

--- a/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
@@ -1,0 +1,335 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024 Juniper Networks, Inc.
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    ApstraClientFactory,
+    apstra_client_module_args,
+)
+
+DOCUMENTATION = """
+---
+module: floating_ip
+short_description: Manage Floating IPs in an Apstra blueprint
+description:
+  - Update, query, or delete Floating IP addresses within an Apstra blueprint.
+  - Floating IPs (VIP endpoints) are typically auto-created by Apstra when
+    Connectivity Templates assign them.  This module allows renaming them
+    (C(label)), setting a C(description), and changing the IP address
+    (C(ipv4_addr) / C(ipv6_addr)).
+  - Use C(state=queried) to list all floating IPs or retrieve a single one.
+  - Use C(state=present) to update an existing floating IP.
+  - Use C(state=absent) to delete a floating IP.
+version_added: "0.1.0"
+author: "Juniper Networks"
+options:
+  id:
+    description:
+      - Identifies the blueprint and optionally the floating IP node.
+      - C(blueprint) (str, required) — blueprint name or UUID.
+      - C(floating_ip) (str, optional) — floating IP node UUID.
+        If omitted, the module searches by C(body.label) or C(body.ipv4_addr).
+    type: dict
+    required: true
+  body:
+    description:
+      - Desired properties of the floating IP.
+      - C(label) (str) — display name shown in the Apstra UI.
+      - C(description) (str) — free-text description.
+      - C(ipv4_addr) (str) — IPv4 address in CIDR format (e.g. C(10.2.22.201/24)).
+      - C(ipv6_addr) (str) — IPv6 address in CIDR format.
+      - When C(state=present), only supplied fields are changed.
+    type: dict
+    required: false
+  state:
+    description:
+      - C(present) — update the floating IP (idempotent).
+      - C(absent) — delete the floating IP.
+      - C(queried) — list all floating IPs or retrieve a single one (read-only).
+    type: str
+    required: false
+    default: present
+    choices: ["present", "absent", "queried"]
+"""
+
+EXAMPLES = """
+# List all floating IPs in a blueprint
+- name: List floating IPs
+  juniper.apstra.floating_ip:
+    id:
+      blueprint: "my-blueprint"
+    state: queried
+  register: fip_result
+
+- name: Show floating IPs
+  ansible.builtin.debug:
+    var: fip_result.floating_ips
+
+# Get a single floating IP by node ID
+- name: Get floating IP by ID
+  juniper.apstra.floating_ip:
+    id:
+      blueprint: "my-blueprint"
+      floating_ip: "{{ fip_node_id }}"
+    state: queried
+  register: fip
+
+# Give a name to an auto-created floating IP (found by IP address)
+- name: Name the floating IP 10.2.22.201/24
+  juniper.apstra.floating_ip:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      ipv4_addr: "10.2.22.201/24"   # used to find the floating IP
+      label: "Tenant5-VIP"
+      description: "Primary VIP for Tenant5"
+    state: present
+
+# Change IP address of a named floating IP
+- name: Update floating IP address
+  juniper.apstra.floating_ip:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "Tenant5-VIP"          # used to find the floating IP
+      ipv4_addr: "10.2.22.210/24"   # new address
+    state: present
+
+# Update by node ID directly
+- name: Update floating IP by node ID
+  juniper.apstra.floating_ip:
+    id:
+      blueprint: "my-blueprint"
+      floating_ip: "{{ fip_node_id }}"
+    body:
+      label: "Tenant5-VIP"
+      ipv4_addr: "10.2.22.201/24"
+    state: present
+
+# Delete a floating IP by label
+- name: Delete floating IP
+  juniper.apstra.floating_ip:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "Tenant5-VIP"
+    state: absent
+"""
+
+RETURN = """
+changed:
+    description: Whether the floating IP was changed.
+    returned: always
+    type: bool
+floating_ip:
+    description: The current state of the floating IP after the operation.
+    returned: when state is present and a single floating IP is targeted
+    type: dict
+    sample:
+        id: "abc123"
+        label: "Tenant5-VIP"
+        description: "Primary VIP for Tenant5"
+        ipv4_addr: "10.2.22.201/24"
+        immutable: false
+floating_ips:
+    description: List of all floating IPs in the blueprint.
+    returned: when state is queried and no floating_ip ID is specified
+    type: list
+    elements: dict
+msg:
+    description: Human-readable result message.
+    returned: always
+    type: str
+"""
+
+
+def _get_blueprint_client(client_factory, blueprint_id):
+    """Return the l3clos blueprint resource handle."""
+    l3clos = client_factory.get_l3clos_client()
+    return l3clos.blueprints[blueprint_id]
+
+
+def _list_all(bp):
+    """Return all floating IPs with IDs via experience/web endpoint."""
+    result = bp.experience.web.floating_ips.get()
+    if result is None:
+        return []
+    if isinstance(result, list):
+        return result
+    return []
+
+
+def _find_by_label(all_fips, label):
+    """Return the first floating IP dict whose label matches."""
+    for fip in all_fips:
+        if fip.get("label") == label:
+            return fip
+    return None
+
+
+def _find_by_ipv4(all_fips, ipv4_addr):
+    """Return the first floating IP dict whose ipv4_addr matches."""
+    for fip in all_fips:
+        if fip.get("ipv4_addr") == ipv4_addr:
+            return fip
+    return None
+
+
+def _needs_update(current, desired):
+    """Return dict of fields that differ between current and desired."""
+    changes = {}
+    for key, value in desired.items():
+        if current.get(key) != value:
+            changes[key] = value
+    return changes
+
+
+def main():
+    object_module_args = dict(
+        id=dict(type="dict", required=True),
+        body=dict(type="dict", required=False),
+        state=dict(
+            type="str",
+            required=False,
+            choices=["present", "absent", "queried"],
+            default="present",
+        ),
+    )
+    client_module_args = apstra_client_module_args()
+    module_args = client_module_args | object_module_args
+
+    result = dict(changed=False)
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=False)
+
+    try:
+        client_factory = ApstraClientFactory.from_params(module)
+
+        id_param = dict(module.params.get("id") or {})
+        body = module.params.get("body") or {}
+        state = module.params["state"]
+
+        blueprint_id = id_param.get("blueprint")
+        if not blueprint_id:
+            raise ValueError("'id.blueprint' is required")
+        blueprint_id = client_factory.resolve_blueprint_id(blueprint_id)
+
+        node_id = id_param.get("floating_ip")
+
+        bp = _get_blueprint_client(client_factory, blueprint_id)
+
+        # ── state=queried ────────────────────────────────────────────────
+        if state == "queried":
+            if node_id:
+                fip = bp.floating_ips[node_id].get()
+                if fip is None:
+                    raise ValueError(
+                        f"Floating IP node '{node_id}' not found in blueprint '{blueprint_id}'"
+                    )
+                result["floating_ip"] = fip
+                result["msg"] = f"floating_ip '{node_id}' retrieved"
+            else:
+                all_fips = _list_all(bp)
+                result["floating_ips"] = all_fips
+                result["msg"] = f"found {len(all_fips)} floating IP(s)"
+            result["changed"] = False
+            module.exit_json(**result)
+            return
+
+        # ── Resolve node_id from body if not provided ────────────────────
+        current_fip = None
+        if not node_id:
+            all_fips = _list_all(bp)
+            label = body.get("label")
+            ipv4_addr = body.get("ipv4_addr")
+
+            # Try label first, then ipv4_addr as fallback lookup key
+            if label:
+                current_fip = _find_by_label(all_fips, label)
+            if current_fip is None and ipv4_addr:
+                current_fip = _find_by_ipv4(all_fips, ipv4_addr)
+
+            if current_fip is None:
+                lookup = repr(label) if label else repr(ipv4_addr)
+                raise ValueError(
+                    f"No floating IP found matching {lookup} "
+                    f"in blueprint '{blueprint_id}'. "
+                    "Provide id.floating_ip (node UUID) or body.label / body.ipv4_addr."
+                )
+            node_id = current_fip["id"]
+        else:
+            # Fetch current state by node_id from experience/web (includes id + immutable)
+            all_fips = _list_all(bp)
+            for fip in all_fips:
+                if fip.get("id") == node_id:
+                    current_fip = fip
+                    break
+            if current_fip is None:
+                raise ValueError(
+                    f"Floating IP node '{node_id}' not found in blueprint '{blueprint_id}'"
+                )
+
+        result["id"] = {"blueprint": blueprint_id, "floating_ip": node_id}
+
+        # ── state=absent ─────────────────────────────────────────────────
+        if state == "absent":
+            bp.floating_ips[node_id].delete()
+            result["changed"] = True
+            result["msg"] = f"floating_ip '{node_id}' deleted"
+            module.exit_json(**result)
+            return
+
+        # ── state=present ────────────────────────────────────────────────
+        # Build the patch payload — only fields explicitly in body
+        patchable = {}
+        for field in ("label", "description", "ipv4_addr", "ipv6_addr"):
+            if field in body:
+                patchable[field] = body[field]
+
+        if not patchable:
+            result["changed"] = False
+            result["floating_ip"] = current_fip
+            result["msg"] = "no fields to update"
+            module.exit_json(**result)
+            return
+
+        changes = _needs_update(current_fip, patchable)
+        if not changes:
+            result["changed"] = False
+            result["floating_ip"] = current_fip
+            result["msg"] = "floating_ip already up to date, no change"
+            module.exit_json(**result)
+            return
+
+        bp.floating_ips[node_id].patch(changes)
+        result["changed"] = True
+        result["changes"] = changes
+
+        # Return updated state
+        updated = bp.floating_ips[node_id].get() or {}
+        # Merge id back in (get() response doesn't include it)
+        updated["id"] = node_id
+        result["floating_ip"] = updated
+        result["msg"] = (
+            f"floating_ip '{node_id}' updated: {', '.join(changes.keys())}"
+        )
+
+    except Exception as e:
+        tb = traceback.format_exc()
+        module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        module.fail_json(msg=str(e), **result)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/juniper/apstra/tests/floating_ip.yml
+++ b/ansible_collections/juniper/apstra/tests/floating_ip.yml
@@ -208,6 +208,130 @@
         that:
           - fip_update_by_ip.id.floating_ip == fip_node_id
 
+    # ── Create a security zone + virtual network for VN lookup test ───
+    - name: Create routing policy for security zone
+      juniper.apstra.routing_policy:
+        id: "{{ bp.id }}"
+        body:
+          label: "fip_test_rp"
+          policy_type: "user_defined"
+          import_policy: "all"
+          export_policy:
+            l2edge_subnets: true
+            loopbacks: true
+            spine_leaf_links: false
+            spine_superspine_links: false
+            static_routes: false
+          expect_default_ipv4_route: false
+          expect_default_ipv6_route: false
+        auth_token: "{{ auth.token }}"
+      register: fip_rp
+
+    - name: Create security zone for VN lookup test
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        body:
+          label: "fip-test-vrf"
+          vrf_name: "fip_test_vrf"
+          sz_type: "evpn"
+          vni_id: 16777200
+          vlan_id: 2040
+          routing_policy_id: "{{ fip_rp.id.routing_policy }}"
+          junos_evpn_irb_mode: "asymmetric"
+        auth_token: "{{ auth.token }}"
+      register: fip_sz
+
+    - name: Create virtual network for VN lookup test
+      juniper.apstra.virtual_network:
+        id: "{{ bp.id }}"
+        body:
+          label: "fip-test-vn"
+          vn_type: "vxlan"
+          vn_id: 16777100
+          vlan_id: 2041
+          security_zone_id: "{{ fip_sz.id.security_zone }}"
+        auth_token: "{{ auth.token }}"
+      register: fip_vn
+
+    - name: Show created virtual network
+      ansible.builtin.debug:
+        var: fip_vn
+
+    # ── Create a floating IP associated with the VN ───────────────────
+    - name: Create floating IP associated with virtual network
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        body:
+          ipv4_addr: "10.99.3.1/24"
+          virtual_network_id: "{{ fip_vn.id.virtual_network }}"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: fip_vn_create
+
+    - name: Show VN-associated floating IP
+      ansible.builtin.debug:
+        var: fip_vn_create
+
+    - name: Save VN-associated floating IP node ID
+      ansible.builtin.set_fact:
+        fip_vn_node_id: "{{ fip_vn_create.id.floating_ip }}"
+
+    # ── Update by VN name (virtual_network lookup) ────────────────────
+    - name: Update floating IP using VN name lookup
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        body:
+          virtual_network: "fip-test-vn"   # VN name — used to FIND the floating IP
+          label: "fip-test-vn-vip"         # new label to set via PATCH
+          description: "Named via VN lookup"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: fip_vn_lookup
+
+    - name: Show VN-lookup update result
+      ansible.builtin.debug:
+        var: fip_vn_lookup
+
+    - name: Verify VN lookup found the correct floating IP
+      ansible.builtin.assert:
+        that:
+          - fip_vn_lookup.changed == true
+          - fip_vn_lookup.id.floating_ip == fip_vn_node_id
+          - fip_vn_lookup.floating_ip.label == "fip-test-vn-vip"
+
+    # ── Idempotent VN lookup (no change) ─────────────────────────────
+    - name: VN lookup update with same values (no change expected)
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        body:
+          virtual_network: "fip-test-vn"
+          label: "fip-test-vn-vip"
+          description: "Named via VN lookup"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: fip_vn_nochange
+
+    - name: Show VN lookup no-change result
+      ansible.builtin.debug:
+        var: fip_vn_nochange
+
+    - name: Verify no change on second VN lookup
+      ansible.builtin.assert:
+        that:
+          - fip_vn_nochange.changed == false
+
+    # ── Delete VN-associated floating IP ─────────────────────────────
+    - name: Delete VN-associated floating IP by node ID
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+          floating_ip: "{{ fip_vn_node_id }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
     # ── Blueprint name resolution (by name not UUID) ──────────────────
     - name: List floating IPs using blueprint name (not UUID)
       juniper.apstra.floating_ip:

--- a/ansible_collections/juniper/apstra/tests/floating_ip.yml
+++ b/ansible_collections/juniper/apstra/tests/floating_ip.yml
@@ -1,0 +1,350 @@
+---
+- name: Test create/update/query/delete floating_ip
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Get local hostname
+      ansible.builtin.command: hostname
+      register: local_hostname
+      changed_when: false
+
+    - name: Set blueprint name fact
+      ansible.builtin.set_fact:
+        blueprint_name: "test_fip_{{ local_hostname.stdout }}"
+
+    - name: Connect to Apstra
+      juniper.apstra.authenticate:
+        logout: false
+      register: auth
+
+    - name: Create blueprint
+      juniper.apstra.blueprint:
+        body:
+          design: "two_stage_l3clos"
+          init_type: "template_reference"
+          template_id: "L2_Virtual_EVPN"
+          label: "{{ blueprint_name }}"
+        lock_state: "ignore"
+        auth_token: "{{ auth.token }}"
+      register: bp
+
+    - name: Show created blueprint
+      ansible.builtin.debug:
+        var: bp
+
+    # ── List (empty) ──────────────────────────────────────────────────
+    - name: List all floating IPs (should be empty initially)
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: fip_list_empty
+
+    - name: Show empty floating IP list
+      ansible.builtin.debug:
+        var: fip_list_empty
+
+    - name: Verify empty list result
+      ansible.builtin.assert:
+        that:
+          - fip_list_empty.changed == false
+          - fip_list_empty.floating_ips is defined
+          - fip_list_empty.floating_ips | length == 0
+
+    # ── Create ────────────────────────────────────────────────────────
+    - name: Create a floating IP
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        body:
+          label: "test-vip-1"
+          description: "Test VIP created by ansible"
+          ipv4_addr: "10.99.1.1/24"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: fip_create
+
+    - name: Show created floating IP
+      ansible.builtin.debug:
+        var: fip_create
+
+    - name: Verify create result
+      ansible.builtin.assert:
+        that:
+          - fip_create.changed == true
+          - fip_create.floating_ip is defined
+          - fip_create.id.floating_ip is defined
+
+    - name: Save floating IP node ID
+      ansible.builtin.set_fact:
+        fip_node_id: "{{ fip_create.id.floating_ip }}"
+
+    # ── List (non-empty) ──────────────────────────────────────────────
+    - name: List all floating IPs (should have one now)
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: fip_list
+
+    - name: Show floating IP list
+      ansible.builtin.debug:
+        var: fip_list
+
+    - name: Verify list has the created floating IP
+      ansible.builtin.assert:
+        that:
+          - fip_list.floating_ips | length >= 1
+          - fip_list.floating_ips | selectattr('id', 'equalto', fip_node_id) | list | length == 1
+
+    # ── Query single ──────────────────────────────────────────────────
+    - name: Query single floating IP by node ID
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+          floating_ip: "{{ fip_node_id }}"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: fip_single
+
+    - name: Show single floating IP
+      ansible.builtin.debug:
+        var: fip_single
+
+    - name: Verify single query
+      ansible.builtin.assert:
+        that:
+          - fip_single.changed == false
+          - fip_single.floating_ip is defined
+
+    # ── Update by node ID ─────────────────────────────────────────────
+    - name: Update floating IP label and description by node ID
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+          floating_ip: "{{ fip_node_id }}"
+        body:
+          label: "test-vip-renamed"
+          description: "Updated description"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: fip_update
+
+    - name: Show updated floating IP
+      ansible.builtin.debug:
+        var: fip_update
+
+    - name: Verify update result
+      ansible.builtin.assert:
+        that:
+          - fip_update.changed == true
+          - fip_update.floating_ip.label == "test-vip-renamed"
+
+    # ── Idempotent update (no change) ─────────────────────────────────
+    - name: Update floating IP with same values (no change expected)
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+          floating_ip: "{{ fip_node_id }}"
+        body:
+          label: "test-vip-renamed"
+          description: "Updated description"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: fip_nochange
+
+    - name: Show no-change result
+      ansible.builtin.debug:
+        var: fip_nochange
+
+    - name: Verify no change
+      ansible.builtin.assert:
+        that:
+          - fip_nochange.changed == false
+
+    # ── Update by label (name lookup) ─────────────────────────────────
+    - name: Update floating IP by label (lookup by label)
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        body:
+          label: "test-vip-renamed"
+          ipv4_addr: "10.99.1.2/24"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: fip_update_by_label
+
+    - name: Show label-lookup update result
+      ansible.builtin.debug:
+        var: fip_update_by_label
+
+    - name: Verify update by label
+      ansible.builtin.assert:
+        that:
+          - fip_update_by_label.changed == true
+          - fip_update_by_label.id.floating_ip == fip_node_id
+
+    # ── Update by IPv4 (ipv4_addr lookup) ─────────────────────────────
+    - name: Update floating IP by ipv4_addr lookup
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        body:
+          ipv4_addr: "10.99.1.2/24"
+          description: "Found by IP"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: fip_update_by_ip
+
+    - name: Show ipv4-lookup update result
+      ansible.builtin.debug:
+        var: fip_update_by_ip
+
+    - name: Verify update by ipv4_addr
+      ansible.builtin.assert:
+        that:
+          - fip_update_by_ip.id.floating_ip == fip_node_id
+
+    # ── Blueprint name resolution (by name not UUID) ──────────────────
+    - name: List floating IPs using blueprint name (not UUID)
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ blueprint_name }}"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: fip_by_name
+
+    - name: Show result from blueprint name lookup
+      ansible.builtin.debug:
+        var: fip_by_name
+
+    - name: Verify blueprint name lookup works
+      ansible.builtin.assert:
+        that:
+          - fip_by_name.floating_ips | length >= 1
+
+    # ── Create second floating IP ─────────────────────────────────────
+    - name: Create second floating IP
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        body:
+          label: "test-vip-2"
+          ipv4_addr: "10.99.2.1/24"
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: fip_create2
+
+    - name: Show second floating IP
+      ansible.builtin.debug:
+        var: fip_create2
+
+    - name: Save second floating IP node ID
+      ansible.builtin.set_fact:
+        fip_node_id2: "{{ fip_create2.id.floating_ip }}"
+
+    # ── List (two floating IPs) ───────────────────────────────────────
+    - name: List all floating IPs (should have two now)
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: fip_list2
+
+    - name: Show final floating IP list
+      ansible.builtin.debug:
+        var: fip_list2
+
+    - name: Verify two floating IPs exist
+      ansible.builtin.assert:
+        that:
+          - fip_list2.floating_ips | length >= 2
+
+    # ── Delete first floating IP ──────────────────────────────────────
+    - name: Delete first floating IP by node ID
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+          floating_ip: "{{ fip_node_id }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: fip_delete1
+
+    - name: Show delete result
+      ansible.builtin.debug:
+        var: fip_delete1
+
+    - name: Verify delete changed
+      ansible.builtin.assert:
+        that:
+          - fip_delete1.changed == true
+
+    # ── Delete second floating IP by label ────────────────────────────
+    - name: Delete second floating IP by label
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        body:
+          label: "test-vip-2"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: fip_delete2
+
+    - name: Show second delete result
+      ansible.builtin.debug:
+        var: fip_delete2
+
+    - name: Verify second delete changed
+      ansible.builtin.assert:
+        that:
+          - fip_delete2.changed == true
+
+    # ── List (empty again) ────────────────────────────────────────────
+    - name: List all floating IPs (should be empty again)
+      juniper.apstra.floating_ip:
+        id:
+          blueprint: "{{ bp.id }}"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: fip_list_final
+
+    - name: Show final list
+      ansible.builtin.debug:
+        var: fip_list_final
+
+    - name: Verify all floating IPs deleted
+      ansible.builtin.assert:
+        that:
+          - fip_list_final.floating_ips | length == 0
+
+    # ── Cleanup ───────────────────────────────────────────────────────
+    - name: Unlock the blueprint
+      juniper.apstra.blueprint:
+        id: "{{ bp.id }}"
+        lock_state: "unlocked"
+        auth_token: "{{ auth.token }}"
+      register: blueprint_unlock
+
+    - name: Show unlocked blueprint
+      ansible.builtin.debug:
+        var: blueprint_unlock
+
+    - name: Delete blueprint
+      juniper.apstra.blueprint:
+        id: "{{ bp.id }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: blueprint_delete
+
+    - name: Show deleted blueprint
+      ansible.builtin.debug:
+        var: blueprint_delete
+
+    - name: Logout of Apstra
+      juniper.apstra.authenticate:
+        logout: true
+        auth_token: "{{ auth.token }}"


### PR DESCRIPTION
Add floating_ip module for managing blueprint Floating IPs
New module to update Floating IPs (VIPs) that are auto-created by
Apstra Connectivity Templates. Supports:
- Lookup by node UUID (id.floating_ip), label, or ipv4_addr
- Update label, description, ipv4_addr, ipv6_addr (idempotent)
- Delete a floating IP
- List all / get single (state=queried)
