### PR TITLE
fix(apstra): prevent KeyError in exception handlers by removing duplicate 'msg'

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/apstra_facts.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/apstra_facts.py
@@ -256,9 +256,7 @@ def main():
                 blueprint_id = id_param.get("blueprint")
                 qe_query_str = filter_param.get("blueprints.qe")
                 if not blueprint_id:
-                    module.fail_json(
-                        msg="'blueprints.qe' requires 'blueprint' in id"
-                    )
+                    module.fail_json(msg="'blueprints.qe' requires 'blueprint' in id")
                 if not qe_query_str:
                     module.fail_json(
                         msg="'blueprints.qe' requires the query string in "
@@ -302,6 +300,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/authenticate.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/authenticate.py
@@ -123,6 +123,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -1051,6 +1051,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
@@ -440,6 +440,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/configlets.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/configlets.py
@@ -710,6 +710,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
@@ -1061,6 +1061,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
@@ -468,6 +468,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/endpoint_policy.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/endpoint_policy.py
@@ -502,6 +502,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/external_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/external_gateway.py
@@ -439,6 +439,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/fabric_settings.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/fabric_settings.py
@@ -305,6 +305,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
@@ -420,6 +420,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/iba_probes.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/iba_probes.py
@@ -841,6 +841,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
@@ -805,6 +805,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -432,6 +432,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/os_upgrade.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/os_upgrade.py
@@ -446,6 +446,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/property_set.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/property_set.py
@@ -603,6 +603,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/resource_group.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/resource_group.py
@@ -289,6 +289,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/resource_pools.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/resource_pools.py
@@ -914,6 +914,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/rollback.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/rollback.py
@@ -212,6 +212,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/routing_policy.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/routing_policy.py
@@ -290,6 +290,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/system_agents.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/system_agents.py
@@ -1016,6 +1016,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/tag.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/tag.py
@@ -253,6 +253,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/upgrade_group.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/upgrade_group.py
@@ -665,6 +665,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
@@ -922,6 +922,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -444,6 +444,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/plugins/modules/ztp_device.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/ztp_device.py
@@ -499,6 +499,7 @@ def main():
     except Exception as e:
         tb = traceback.format_exc()
         module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
         module.fail_json(msg=str(e), **result)
 
     module.exit_json(**result)

--- a/ansible_collections/juniper/apstra/tests/os_upgrade.yml
+++ b/ansible_collections/juniper/apstra/tests/os_upgrade.yml
@@ -25,8 +25,11 @@
 # Usage:
 #   make test-os_upgrade
 #   make test-os_upgrade ANSIBLE_FLAGS="-v"
-#   # With a different blueprint:
+#   # With a specific blueprint (auto-discovers first available blueprint if omitted):
+#   make test-os_upgrade ANSIBLE_FLAGS="-v -e blueprint=my-blueprint"
 #   make test-os_upgrade ANSIBLE_FLAGS="-v -e blueprint_label=my-blueprint"
+#   # With a specific device (auto-discovers first system node if omitted):
+#   make test-os_upgrade ANSIBLE_FLAGS="-v -e blueprint=my-blueprint -e device_label=my-leaf1"
 
 - name: Test juniper.apstra.os_upgrade
   hosts: localhost
@@ -34,13 +37,15 @@
   connection: local
 
   vars:
-    # Blueprint that already exists on the local Apstra server.
-    # Override with -e blueprint_label=<name> if needed.
-    blueprint_label: "{{ blueprint | default('vg-am-cops-tb-0') }}"
+    # Blueprint to test against.  Override with -e blueprint_label=<name>
+    # or -e blueprint=<name>.  If neither is set, the first available
+    # blueprint on the server is auto-discovered.
+    blueprint_label: "{{ blueprint | default('') }}"
 
-    # A device node label that exists in the blueprint above.
-    # Used for single-device impact_report and expected-error tests.
-    device_label: "{{ esi_leaf1 | default('vg-am-cops-tb-0-leaf1') }}"
+    # A device node label in that blueprint used for single-device tests.
+    # Override with -e device_label=<name> or -e esi_leaf1=<name>.
+    # If neither is set, the first system node in the blueprint is auto-discovered.
+    device_label: "{{ esi_leaf1 | default('') }}"
 
   tasks:
     # ── Auth ──────────────────────────────────────────────────────
@@ -48,6 +53,53 @@
       juniper.apstra.authenticate:
         logout: false
       register: auth
+
+    # ── Auto-discover blueprint if not specified ───────────────────
+    - name: "Discover: list all blueprints (skip if blueprint_label set)"
+      juniper.apstra.apstra_facts:
+        auth_token: "{{ auth.token }}"
+        gather_network_facts:
+          - blueprints
+      register: all_bp_facts
+      when: blueprint_label == ''
+
+    - name: "Discover: set blueprint_label to first available blueprint"
+      ansible.builtin.set_fact:
+        blueprint_label: >-
+          {{ all_bp_facts.ansible_facts.apstra_facts.blueprints
+             | dict2items | map(attribute='value.label') | first }}
+      when: blueprint_label == ''
+
+    - name: "Show blueprint in use"
+      ansible.builtin.debug:
+        msg: "Using blueprint: {{ blueprint_label }}"
+
+    # ── Auto-discover device if not specified ──────────────────────
+    - name: "Discover: get system nodes from blueprint (skip if device_label set)"
+      juniper.apstra.apstra_facts:
+        auth_token: "{{ auth.token }}"
+        id:
+          blueprint: "{{ blueprint_label }}"
+        gather_network_facts:
+          - blueprints.nodes
+        filter:
+          blueprints.nodes: "node_type=system"
+      register: bp_node_facts
+      when: device_label == ''
+
+    - name: "Discover: set device_label to first managed system node in blueprint"
+      ansible.builtin.set_fact:
+        device_label: >-
+          {{ (bp_node_facts.ansible_facts.apstra_facts.blueprints
+              | dict2items | first).value.nodes
+             | dict2items
+             | selectattr('value.management_level', 'eq', 'full_control')
+             | map(attribute='value.label') | first }}
+      when: device_label == ''
+
+    - name: "Show device in use"
+      ansible.builtin.debug:
+        msg: "Using device: {{ device_label }}"
 
     # ── Test 1: state=gathered ─────────────────────────────────────
     # Lists OS images globally.  Always read-only.


### PR DESCRIPTION

Some modules set result['msg'] during normal operation; when an exception occurs the handler called module.fail_json(msg=str(e), **result), passing 'msg' twice and raising KeyError. Pop 'msg' from result before calling fail_json so the real exception message is reported. Updated multiple modules under plugins/modules to apply the fix.