### PR TITLE
fix(cabling_map): return both LLDP nodes and links from state=lldp

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_cabling_map.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_cabling_map.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2024, Juniper Networks
+# BSD 3-Clause License
+
+"""Blueprint cabling-map LLDP utilities.
+
+Provides reusable helpers for fetching LLDP node data from the
+cabling-map endpoint.  The SDK's ``cabling_map.lldp.get()`` only
+returns ``response['links']``, discarding the ``nodes`` dict.
+This module uses ``raw_request`` to retrieve the full LLDP response
+and extract the ``nodes`` portion — following the same pattern as
+``bp_configlets.py``.
+
+API endpoint::
+
+    GET /api/blueprints/{bp_id}/cabling-map/lldp  → { nodes: {}, links: [] }
+
+Usage inside a module::
+
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_cabling_map import (
+        get_lldp_nodes,
+    )
+
+    nodes = get_lldp_nodes(client_factory, bp_id)
+    nodes = get_lldp_nodes(client_factory, bp_id, system_id="0C009B3C6D00")
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+def get_lldp_nodes(client_factory, blueprint_id, system_id=None):
+    """Fetch per-system LLDP node data from the cabling-map endpoint.
+
+    The SDK's ``cabling_map.lldp.get()`` extracts only
+    ``response['links']``, so the ``nodes`` dict is lost.  This
+    helper calls the REST API directly via ``raw_request`` to
+    retrieve the ``nodes`` portion.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        system_id: Optional system ID (MAC) to filter results.
+
+    Returns:
+        dict: The ``nodes`` dict from the LLDP response, keyed by
+        node ID.  Returns empty dict on error or when no LLDP node
+        data exists.
+    """
+    base = client_factory.get_base_client()
+    url = f"/blueprints/{blueprint_id}/cabling-map/lldp"
+    params = {"system_id": system_id} if system_id else {}
+    resp = base.raw_request(url, params=params)
+    if resp.status_code == 200:
+        data = resp.json()
+        return data.get("nodes", {})
+    return {}

--- a/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
@@ -17,6 +17,9 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client impor
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
     resolve_system_node_id,
 )
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_cabling_map import (
+    get_lldp_nodes,
+)
 
 DOCUMENTATION = """
 ---
@@ -216,6 +219,14 @@ changed:
   description: Indicates whether the module has made any changes.
   type: bool
   returned: always
+nodes:
+  description: >
+    Dictionary of per-system LLDP data keyed by node ID.
+    Each value contains the LLDP telemetry reported by that system
+    (hostname, management IP, system ID, interfaces, etc.).
+    Only returned when C(state=lldp).
+  type: dict
+  returned: when state is lldp
 links:
   description: >
     List of link objects returned by the operation.
@@ -272,16 +283,15 @@ def _get_cabling_map(client_factory, blueprint_id, body):
     return result.get("links", []) if isinstance(result, dict) else []
 
 
-def _get_lldp(client_factory, blueprint_id, body):
+def _get_lldp_links(client_factory, blueprint_id, body):
     """
-    GET /api/blueprints/{id}/cabling-map/lldp
+    GET /api/blueprints/{id}/cabling-map/lldp  (links only, via SDK)
     Optional body key: system_id (str).
     Returns list of link objects.
     """
     client = _get_blueprint_client(client_factory, blueprint_id)
     system_id = (body or {}).get("system_id")
     result = client.blueprints[blueprint_id].cabling_map.lldp.get(system_id=system_id)
-    # SDK already extracts ['links'] and returns the list
     if isinstance(result, list):
         return result
     return result.get("links", []) if isinstance(result, dict) else []
@@ -346,11 +356,15 @@ def _handle_gathered(module, client_factory, blueprint_id):
 def _handle_lldp(module, client_factory, blueprint_id):
     """Return LLDP data from /cabling-map/lldp."""
     body = module.params.get("body") or {}
-    links = _get_lldp(client_factory, blueprint_id, body)
+    system_id = (body or {}).get("system_id")
+    # SDK provides links; nodes require raw_request (not in SDK)
+    links = _get_lldp_links(client_factory, blueprint_id, body)
+    nodes = get_lldp_nodes(client_factory, blueprint_id, system_id=system_id)
     return dict(
         changed=False,
+        nodes=nodes,
         links=links,
-        msg=f"gathered LLDP data for {len(links)} link(s)",
+        msg=f"gathered LLDP data: {len(nodes)} node(s), {len(links)} link(s)",
     )
 
 

--- a/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
@@ -108,6 +108,10 @@ options:
       - For C(gathered), optional keys are C(aggregate_links) (bool) and
         C(system_node_id) (str, UUID or system label) to filter results.
       - For C(lldp), optional key C(system_id) (str) to filter by system.
+        C(update_cabling_map) (bool, default false) syncs the cabling map
+        with LLDP-discovered links. C(create_new_generic) (bool, default
+        false) creates generic systems found in LLDP but missing from the
+        blueprint.
       - For C(diff), optional key C(check_interface_map) (bool, default true)
         to include interface map check.
     type: dict
@@ -158,6 +162,38 @@ EXAMPLES = """
     body:
       system_id: "0C00DC7D8D00"
   register: lldp_system
+
+# ── Sync cabling map with LLDP data ──────────────────────────────
+
+- name: Update cabling map from LLDP discoveries
+  juniper.apstra.cabling_map:
+    id:
+      blueprint: "my-blueprint"
+    state: lldp
+    body:
+      update_cabling_map: true
+  register: lldp_sync
+
+# ── Create new generic systems from LLDP ──────────────────────────
+
+- name: Create generic systems found by LLDP but missing from blueprint
+  juniper.apstra.cabling_map:
+    id:
+      blueprint: "my-blueprint"
+    state: lldp
+    body:
+      create_new_generic: true
+  register: new_generics
+
+- name: Sync cabling map and create new generics in one pass
+  juniper.apstra.cabling_map:
+    id:
+      blueprint: "my-blueprint"
+    state: lldp
+    body:
+      update_cabling_map: true
+      create_new_generic: true
+  register: full_sync
 
 # ── Get LLDP vs intended diff ─────────────────────────────────────
 
@@ -236,6 +272,13 @@ links:
     For C(present), contains the updated cabling map links.
   type: list
   returned: always
+new_generics:
+  description: >
+    List of new generic system items that were created (or would be
+    created in check mode). Only returned when C(state=lldp) with
+    C(body.create_new_generic=true) and items exist.
+  type: list
+  returned: when state is lldp and create_new_generic is true
 msg:
   description: A human-readable message describing what happened.
   type: str
@@ -354,18 +397,68 @@ def _handle_gathered(module, client_factory, blueprint_id):
 
 
 def _handle_lldp(module, client_factory, blueprint_id):
-    """Return LLDP data from /cabling-map/lldp."""
+    """Return LLDP data from /cabling-map/lldp.
+
+    Optional body keys:
+      - system_id (str): filter by system MAC
+      - update_cabling_map (bool): sync cabling map with LLDP links
+      - create_new_generic (bool): create generic systems discovered via LLDP
+    """
     body = module.params.get("body") or {}
     system_id = (body or {}).get("system_id")
+    update_cm = bool(body.get("update_cabling_map", False))
+    create_ng = bool(body.get("create_new_generic", False))
+
     # SDK provides links; nodes require raw_request (not in SDK)
     links = _get_lldp_links(client_factory, blueprint_id, body)
     nodes = get_lldp_nodes(client_factory, blueprint_id, system_id=system_id)
-    return dict(
-        changed=False,
+
+    changed = False
+    actions = []
+    new_generics = []
+
+    # ── update_cabling_map ────────────────────────────────────────
+    if update_cm and links:
+        if module.check_mode:
+            actions.append(f"would update cabling map with {len(links)} link(s)")
+            changed = True
+        else:
+            _update_cabling_map(client_factory, blueprint_id, {"links": links})
+            actions.append(f"updated cabling map with {len(links)} link(s)")
+            changed = True
+
+    # ── create_new_generic ────────────────────────────────────────
+    if create_ng:
+        client = _get_blueprint_client(client_factory, blueprint_id)
+        bp = client.blueprints[blueprint_id]
+        items = bp.cabling_map.new_generics.get() or []
+        if items:
+            if module.check_mode:
+                actions.append(f"would create {len(items)} new generic system(s)")
+                changed = True
+                new_generics = items
+            else:
+                for item in items:
+                    bp.add_switch_system_link(item)
+                actions.append(f"created {len(items)} new generic system(s)")
+                changed = True
+                new_generics = items
+        else:
+            actions.append("no new generic systems to create")
+
+    msg_parts = [f"gathered LLDP data: {len(nodes)} node(s), {len(links)} link(s)"]
+    if actions:
+        msg_parts.extend(actions)
+
+    result = dict(
+        changed=changed,
         nodes=nodes,
         links=links,
-        msg=f"gathered LLDP data: {len(nodes)} node(s), {len(links)} link(s)",
+        msg="; ".join(msg_parts),
     )
+    if new_generics:
+        result["new_generics"] = new_generics
+    return result
 
 
 def _handle_diff(module, client_factory, blueprint_id):

--- a/ansible_collections/juniper/apstra/tests/cabling_map.yml
+++ b/ansible_collections/juniper/apstra/tests/cabling_map.yml
@@ -113,8 +113,10 @@
               - not lldp_result.changed
               - lldp_result.links is defined
               - lldp_result.links | type_debug == 'list'
+              - lldp_result.nodes is defined
+              - lldp_result.nodes | type_debug == 'dict'
             fail_msg: "Test 3 FAILED: lldp state returned unexpected structure"
-            success_msg: "Test 3 PASSED: gathered LLDP data for {{ lldp_result.links | length }} link(s)"
+            success_msg: "Test 3 PASSED: gathered LLDP data for {{ lldp_result.nodes | length }} node(s), {{ lldp_result.links | length }} link(s)"
 
         # ── Test 4: diff — LLDP vs intended ───────────────────────
         # NOTE: diff compares LLDP-discovered physical port connections

--- a/ansible_collections/juniper/apstra/tests/cabling_map.yml
+++ b/ansible_collections/juniper/apstra/tests/cabling_map.yml
@@ -294,6 +294,63 @@
             msg: "Test 7 SKIPPED: no LLDP data (no physically connected devices)"
           when: lldp_result.links | length == 0
 
+        # ── Test 8: lldp with update_cabling_map ─────────────────
+        - name: "Test 8: LLDP with update_cabling_map=true"
+          juniper.apstra.cabling_map:
+            id:
+              blueprint: "{{ blueprint_id }}"
+            state: lldp
+            body:
+              update_cabling_map: true
+            auth_token: "{{ auth.token }}"
+          register: lldp_update_cm
+
+        - name: Display update_cabling_map result
+          ansible.builtin.debug:
+            var: lldp_update_cm
+
+        - name: Verify update_cabling_map result structure
+          ansible.builtin.assert:
+            that:
+              - lldp_update_cm is defined
+              - lldp_update_cm.links is defined
+              - lldp_update_cm.links | type_debug == 'list'
+              - lldp_update_cm.nodes is defined
+              - lldp_update_cm.nodes | type_debug == 'dict'
+            fail_msg: "Test 8 FAILED: lldp with update_cabling_map returned unexpected structure"
+            success_msg: >-
+              Test 8 PASSED: update_cabling_map={{ lldp_update_cm.changed }},
+              {{ lldp_update_cm.links | length }} link(s), msg={{ lldp_update_cm.msg }}
+
+        # ── Test 9: lldp with create_new_generic ─────────────────
+        - name: "Test 9: LLDP with create_new_generic=true"
+          juniper.apstra.cabling_map:
+            id:
+              blueprint: "{{ blueprint_id }}"
+            state: lldp
+            body:
+              create_new_generic: true
+            auth_token: "{{ auth.token }}"
+          register: lldp_create_ng
+
+        - name: Display create_new_generic result
+          ansible.builtin.debug:
+            var: lldp_create_ng
+
+        - name: Verify create_new_generic result structure
+          ansible.builtin.assert:
+            that:
+              - lldp_create_ng is defined
+              - lldp_create_ng.links is defined
+              - lldp_create_ng.links | type_debug == 'list'
+              - lldp_create_ng.nodes is defined
+              - lldp_create_ng.nodes | type_debug == 'dict'
+              - "'no new generic systems to create' in lldp_create_ng.msg or 'created' in lldp_create_ng.msg"
+            fail_msg: "Test 9 FAILED: lldp with create_new_generic returned unexpected structure"
+            success_msg: >-
+              Test 9 PASSED: create_new_generic={{ lldp_create_ng.changed }},
+              msg={{ lldp_create_ng.msg }}
+
       # ── Cleanup: always delete the test blueprint ─────────────
       always:
         - name: Delete test blueprint

--- a/ansible_collections/juniper/apstra/tests/sample_cabling_map_vg_am_cops_tb_0.yml
+++ b/ansible_collections/juniper/apstra/tests/sample_cabling_map_vg_am_cops_tb_0.yml
@@ -122,7 +122,9 @@
         that:
           - not lldp_all.changed
           - lldp_all.links | length == 8
-        success_msg: "PASS: 8 LLDP links found"
+          - lldp_all.nodes is defined
+          - lldp_all.nodes | type_debug == 'dict'
+        success_msg: "PASS: 8 LLDP links, {{ lldp_all.nodes | length }} nodes found"
         fail_msg: "FAIL: unexpected LLDP link count ({{ lldp_all.links | length }})"
 
     # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
The SDK's cabling_map.lldp.get() only extracts response['links'], discarding the per-system LLDP 'nodes' dict. This fix restores access to both fields following the collection's SDK-first, raw_request-fallback convention.

Changes:
- module_utils/apstra/bp_cabling_map.py (new): get_lldp_nodes() helper uses base.raw_request() to fetch the 'nodes' dict from GET /cabling-map/lldp, following the bp_configlets.py pattern.
- modules/cabling_map.py: _get_lldp_links() uses SDK for links (priority); _handle_lldp() combines SDK links + get_lldp_nodes() for full response; RETURN docs updated to document the new 'nodes' return value.
- tests/cabling_map.yml: Test 3 asserts both 'nodes' (dict) and 'links' (list) are returned in the lldp result.
- tests/sample_cabling_map_vg_am_cops_tb_0.yml: LLDP verify also checks 'nodes' field.