### PR TITLE
ansible(sanity): validate-modules: Fix invalid-documentation about Author

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
@@ -42,7 +42,7 @@ short_description: Manage Connectivity Templates in Apstra blueprints
 version_added: "0.1.0"
 
 author:
-  - "Juniper Networks"
+  - "Vamsi Gavini (@vgavini)"
 
 description:
   - This module allows you to create, update, and delete Connectivity

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
@@ -34,7 +34,7 @@ short_description: Assign or unassign Connectivity Templates to application poin
 version_added: "0.1.0"
 
 author:
-  - "Juniper Networks"
+  - "Vamsi Gavini (@vgavini)"
 
 description:
   - This module assigns or unassigns Connectivity Templates (CTs) to

--- a/ansible_collections/juniper/apstra/plugins/modules/external_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/external_gateway.py
@@ -28,7 +28,7 @@ short_description: Manage external (remote) EVPN gateways in Apstra blueprints
 version_added: "0.1.0"
 
 author:
-  - "Juniper Networks"
+  - "Vamsi Gavini (@vgavini)"
 
 description:
   - This module allows you to create, update, and delete external

--- a/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
@@ -34,7 +34,7 @@ description:
   - Use C(state=present) to create or update a floating IP (idempotent).
   - Use C(state=absent) to delete a floating IP.
 version_added: "0.1.0"
-author: "Juniper Networks"
+author:  "Vamsi Gavini (@vgavini)"
 options:
   id:
     description:

--- a/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
@@ -42,7 +42,7 @@ short_description: Manage EVPN Interconnect Domains and their Gateways in Apstra
 version_added: "0.2.0"
 
 author:
-  - "Juniper Networks"
+  - "Prabhanjan KV (@kvp_jnpr)"
 
 description:
   - This module manages both EVPN Interconnect Domains and

--- a/ansible_collections/juniper/apstra/plugins/modules/property_set.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/property_set.py
@@ -28,7 +28,7 @@ module: property_set
 short_description: Manage property sets in Apstra
 version_added: "0.1.0"
 author:
-  - "Juniper Networks"
+  - "Vamsi Gavini (@vgavini)"
 description:
   - This module allows you to create, update, and delete property sets
     in Apstra.

--- a/ansible_collections/juniper/apstra/plugins/modules/rollback.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/rollback.py
@@ -24,7 +24,7 @@ short_description: Manage blueprint rollback and revisions in Apstra
 version_added: "0.1.0"
 
 author:
-  - "Juniper Networks"
+  - "Vamsi Gavini (@vgavini)"
 
 description:
   - This module allows you to rollback a blueprint to a specific revision,

--- a/ansible_collections/juniper/apstra/plugins/modules/ztp_device.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/ztp_device.py
@@ -24,7 +24,7 @@ short_description: Manage ZTP (Zero Touch Provisioning) devices in Apstra
 version_added: "0.1.0"
 
 author:
-  - "Juniper Networks"
+  - "Prabhanjan KV (@kvp_jnpr)"
 
 description:
   - This module allows you to create, delete, and check the status of


### PR DESCRIPTION
example : connectivity_template.py:0:0: invalid-documentation: DOCUMENTATION.author: Invalid author for dictionary value @ data['author']. Got ['Juniper Networks']

need to use Author (@author)

using git history get the original author

we can replace all by Juniper Network (@juniper) also