### PR TITLE
fix: remove stale MANIFEST.json and FILES.json before collection build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ docs: pipenv install
 
 $(APSTRA_COLLECTION_ROOT)/.apstra-collection: $(APSTRA_COLLECTION_ROOT)/requirements.txt $(APSTRA_COLLECTION_ROOT)/galaxy.yml  $(PY_FILES)
 	rm -f juniper-apstra-*.tar.gz
+	rm -f $(APSTRA_COLLECTION_ROOT)/MANIFEST.json $(APSTRA_COLLECTION_ROOT)/FILES.json
 	pipenv run ansible-galaxy collection build $(APSTRA_COLLECTION_ROOT)
 	touch "$@"
 


### PR DESCRIPTION
ansible-galaxy collection build fails when FILES.json content changes but MANIFEST.json still references the old SHA256 checksum. Remove both files before building so they are regenerated with correct checksums.