### PR TITLE
ansible-sanity(validate-modules): fix invalid-documentation: DOCUMENTATION.module:

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/authenticate.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/authenticate.py
@@ -18,7 +18,7 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client impor
 
 DOCUMENTATION = """
 ---
-module: apstra_authenticate
+module: authenticate
 short_description: Apstra authentication
 description:
   - This module authenticates with Apstra and retrieves an authentication token.  It can also handle logout operations.


### PR DESCRIPTION
authenticate.py:0:0: invalid-documentation: DOCUMENTATION.module: not a valid value for dictionary value @ data['module']. Got 'apstra_authenticate'