### PR TITLE
apstra_facts: fix invalid-documentation: DOCUMENTATION.options.xxx.env found by sanity

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/apstra_facts.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/apstra_facts.py
@@ -33,38 +33,30 @@ author: "Edwin Jacques (@edwinpjacques)"
 options:
   api_url:
     description:
-      - The URL used to access the Apstra api.
+      - The URL used to access the Apstra api (APSTRA_API_URL).
     type: str
     required: false
-    env:
-      - name: APSTRA_API_URL
   verify_certificates:
     description:
-      - If set to false, SSL certificates will not be verified.
+      - If set to false, SSL certificates will not be verified (APSTRA_VERIFY_CERTIFICATES).
     type: bool
     required: false
     default: True
   username:
     description:
-      - The username for authentication.
+      - The username for authentication (APSTRA_USERNAME).
     type: str
     required: false
-    env:
-      - name: APSTRA_USERNAME
   password:
     description:
-      - The password for authentication.
+      - The password for authentication (APSTRA_PASSWORD).
     type: str
     required: false
-    env:
-      - name: APSTRA_PASSWORD
   auth_token:
     description:
-      - The authentication token to use if already authenticated.
+      - The authentication token to use if already authenticated (APSTRA_AUTH_TOKEN).
     type: str
     required: false
-    env:
-      - name: APSTRA_AUTH_TOKEN
   gather_network_facts:
     description:
       - List of network objects to gather facts about.


### PR DESCRIPTION
found by validate-modules

apstra_facts.py:0:0: invalid-documentation: DOCUMENTATION.options.api_url.env: extra keys not allowed @ data['options']['api_url']['env']. Got [{'name': 'APSTRA_API_URL'}] apstra_facts.py:0:0: invalid-documentation: DOCUMENTATION.options.auth_token.env: extra keys not allowed @ data['options']['auth_token']['env']. Got [{'name': 'APSTRA_AUTH_TOKEN'}] apstra_facts.py:0:0: invalid-documentation: DOCUMENTATION.options.password.env: extra keys not allowed @ data['options']['password']['env']. Got [{'name': 'APSTRA_PASSWORD'}] apstra_facts.py:0:0: invalid-documentation: DOCUMENTATION.options.username.env: extra keys not allowed @ data['options']['username']['env']. Got [{'name': 'APSTRA_USERNAME'}]