### PR TITLE
Fix Ansible validate-modules issues across all modules

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/apstra_facts.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/apstra_facts.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/apstra_facts.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/apstra_facts.py
@@ -2,23 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# MIT License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
-    get_ct_application_point_ids,
-    run_qe_query,
-)
 
 DOCUMENTATION = """
 ---
@@ -63,7 +51,7 @@ options:
       - Use 'all' to gather facts about all supported network objects.
     type: list
     elements: str
-    required: true
+    required: false
     default: ['blueprints']
   id:
     description:
@@ -77,7 +65,7 @@ options:
       - Key is a type, value is a filter string.
     type: dict
     required: false
-    default: "{'blueprints.nodes': 'node_type=system'}"
+    default: {'blueprints.nodes': 'node_type=system'}
   available_network_facts:
     description:
       - If set to true, the module will return a list of available network objects.
@@ -172,6 +160,19 @@ ansible_facts:
     }
   }
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+    get_ct_application_point_ids,
+    run_qe_query,
+)
 
 
 def main():

--- a/ansible_collections/juniper/apstra/plugins/modules/authenticate.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/authenticate.py
@@ -2,19 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# MIT License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
 
 DOCUMENTATION = """
 ---
@@ -30,7 +22,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -42,19 +33,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   logout:
     description:
       - If set to true, the module will log out the current session.
@@ -93,6 +81,15 @@ token:
   type: str
   sample: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
 
 
 def main():

--- a/ansible_collections/juniper/apstra/plugins/modules/authenticate.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/authenticate.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -2,38 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# MIT License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-
-from time import sleep
-
-from ansible.module_utils.basic import AnsibleModule
-import traceback
-
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    DEFAULT_BLUEPRINT_LOCK_TIMEOUT,
-    DEFAULT_BLUEPRINT_COMMIT_TIMEOUT,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
-    run_qe_query,
-    find_nodes_by_role,
-    find_nodes_by_type,
-    find_interfaces_by_neighbor,
-    find_host_bond_interfaces,
-    find_host_evpn_interfaces,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes import (
-    get_node,
-    list_nodes,
-    patch_node,
-    node_needs_update,
-    assign_nodes_by_label,
-)
 
 DOCUMENTATION = """
 ---
@@ -58,7 +31,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -70,19 +42,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - The ID of the blueprint.
@@ -127,6 +96,12 @@ options:
       - Only used when C(state=committed).
     required: false
     type: str
+  unlock:
+    description:
+      - When set to C(true), unlocks the blueprint after the operation completes.
+    required: false
+    type: bool
+    default: false
   state:
     description:
       - The desired state of the blueprint.
@@ -536,6 +511,34 @@ node:
     returned: when using node_updated
     type: dict
 """
+
+from time import sleep
+
+from ansible.module_utils.basic import AnsibleModule
+import traceback
+
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    DEFAULT_BLUEPRINT_LOCK_TIMEOUT,
+    DEFAULT_BLUEPRINT_COMMIT_TIMEOUT,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+    run_qe_query,
+    find_nodes_by_role,
+    find_nodes_by_type,
+    find_interfaces_by_neighbor,
+    find_host_bond_interfaces,
+    find_host_evpn_interfaces,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes import (
+    get_node,
+    list_nodes,
+    patch_node,
+    node_needs_update,
+    assign_nodes_by_label,
+)
+
 
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
     resolve_template_id as _resolve_template_id,

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/cabling_map.py
@@ -2,24 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_system_node_id,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_cabling_map import (
-    get_lldp_nodes,
-)
 
 DOCUMENTATION = """
 ---
@@ -52,7 +39,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -64,19 +50,16 @@ options:
       - The Apstra username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The Apstra password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   state:
     description:
       - The operation to perform.
@@ -284,6 +267,20 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_system_node_id,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_cabling_map import (
+    get_lldp_nodes,
+)
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/configlets.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/configlets.py
@@ -2,29 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_configlets import (
-    get_blueprint_configlet,
-    create_blueprint_configlet,
-    update_blueprint_configlet,
-    delete_blueprint_configlet,
-    find_blueprint_configlet_by_label,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_configlet_id,
-)
 
 DOCUMENTATION = """
 ---
@@ -52,7 +34,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -64,19 +45,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   type:
     description:
       - The type of configlet to manage.
@@ -355,6 +333,26 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_configlets import (
+    get_blueprint_configlet,
+    create_blueprint_configlet,
+    update_blueprint_configlet,
+    delete_blueprint_configlet,
+    find_blueprint_configlet_by_label,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_configlet_id,
+)
+
 
 # Read-only top-level fields returned by the API for catalog configlets
 CATALOG_READ_ONLY_FIELDS = ("id", "created_at", "last_modified_at")

--- a/ansible_collections/juniper/apstra/plugins/modules/configlets.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/configlets.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template.py
@@ -2,36 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import time
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
-
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.ct_validator import (
-    validate_primitives,
-    CTValidationError,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.ct_builder import (
-    build_ct_payload,
-    get_ct_id_from_hierarchy,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.ct_parser import (
-    parse_ct_export,
-    normalize_for_compare,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_ct_primitives,
-)
-
 
 DOCUMENTATION = """
 ---
@@ -72,7 +47,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -84,19 +58,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - A dict identifying the target blueprint and optionally an
@@ -747,6 +718,31 @@ msg:
   type: str
   returned: always
 """
+
+import time
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.ct_validator import (
+    validate_primitives,
+    CTValidationError,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.ct_builder import (
+    build_ct_payload,
+    get_ct_id_from_hierarchy,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.ct_parser import (
+    parse_ct_export,
+    normalize_for_compare,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_ct_primitives,
+)
 
 
 # ── Helper functions ──────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
@@ -2,28 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import re
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    AOS_IMPORT_ERROR,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_application_point_ids,
-)
-
-if not AOS_IMPORT_ERROR:
-    from aos.sdk.reference_design.extension.endpoint_policy import (
-        generator as ct_gen,
-    )
 
 DOCUMENTATION = """
 ---
@@ -54,7 +37,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -66,19 +48,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Identifies the blueprint and connectivity template.
@@ -226,6 +205,24 @@ msg:
   type: str
   returned: always
 """
+
+import re
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    AOS_IMPORT_ERROR,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_application_point_ids,
+)
+
+if not AOS_IMPORT_ERROR:
+    from aos.sdk.reference_design.extension.endpoint_policy import (
+        generator as ct_gen,
+    )
 
 
 # ── Helper functions ──────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/design.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/design.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/design.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/design.py
@@ -2,32 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# MIT License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
-
-try:
-    import aos.sdk.generator as g
-except ImportError:
-    g = None
-
-try:
-    from aos.sdk.interface_map.interface_map_generator import (
-        gen_interface_map as _sdk_gen_interface_map,
-    )
-except ImportError:
-    _sdk_gen_interface_map = None
 
 DOCUMENTATION = """
 ---
@@ -56,6 +35,16 @@ options:
     type: bool
     required: false
     default: true
+  username:
+    description:
+      - The username for authentication.
+    type: str
+    required: false
+  password:
+    description:
+      - The password for authentication.
+    type: str
+    required: false
   auth_token:
     description:
       - The authentication token to use if already authenticated.
@@ -257,6 +246,27 @@ changed:
   type: bool
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+
+try:
+    import aos.sdk.generator as g
+except ImportError:
+    g = None
+
+try:
+    from aos.sdk.interface_map.interface_map_generator import (
+        gen_interface_map as _sdk_gen_interface_map,
+    )
+except ImportError:
+    _sdk_gen_interface_map = None
 
 
 # ── Logical Device Helpers ───────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/endpoint_policy.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/endpoint_policy.py
@@ -2,25 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-    plural_leaf_object_type,
-    AOS_IMPORT_ERROR,
-)
-
-if not AOS_IMPORT_ERROR:
-    from aos.sdk.graph import query
-    from aos.sdk.graph.matchers import aeq
 
 DOCUMENTATION = """
 ---
@@ -37,7 +23,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -49,19 +34,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing the blueprint and endpoint policy IDs.
@@ -86,6 +68,8 @@ options:
   tags:
     description:
       - List of tags to apply to the endpoint policy.
+    type: list
+    elements: str
   state:
     description:
       - Desired state of the endpoint policy.
@@ -195,6 +179,21 @@ msg:
   returned: always
 """
 
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+    plural_leaf_object_type,
+    AOS_IMPORT_ERROR,
+)
+
+if not AOS_IMPORT_ERROR:
+    from aos.sdk.graph import query
+    from aos.sdk.graph.matchers import aeq
+
 
 def main():
     object_module_args = dict(
@@ -204,7 +203,7 @@ def main():
         state=dict(
             type="str", required=False, choices=["present", "absent"], default="present"
         ),
-        tags=dict(type="list", required=False),
+        tags=dict(type="list", elements="str", required=False),
     )
     client_module_args = apstra_client_module_args()
     module_args = client_module_args | object_module_args

--- a/ansible_collections/juniper/apstra/plugins/modules/endpoint_policy.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/endpoint_policy.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/external_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/external_gateway.py
@@ -2,22 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_system_node_id,
-)
 
 DOCUMENTATION = """
 ---
@@ -46,7 +35,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -58,19 +46,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing the blueprint and remote gateway IDs.
@@ -229,6 +214,18 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_system_node_id,
+)
 
 
 def _find_gateway_by_name(client_factory, object_type, id, gw_name):

--- a/ansible_collections/juniper/apstra/plugins/modules/external_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/external_gateway.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/fabric_settings.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/fabric_settings.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/fabric_settings.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/fabric_settings.py
@@ -2,18 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
 
 DOCUMENTATION = """
 ---
@@ -44,7 +37,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -56,19 +48,16 @@ options:
       - The Apstra username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The Apstra password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Identifies the blueprint scope.
@@ -179,6 +168,14 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-# Copyright (c) 2024 Juniper Networks, Inc.
+# Copyright (c) 2024, Juniper Networks
 # Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function

--- a/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
@@ -8,18 +8,6 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import traceback
-import uuid
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    ApstraClientFactory,
-    apstra_client_module_args,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_virtual_network_id,
-)
-
 DOCUMENTATION = """
 ---
 module: floating_ip
@@ -36,6 +24,32 @@ description:
 version_added: "0.1.0"
 author:  "Vamsi Gavini (@vgavini)"
 options:
+  api_url:
+    description:
+      - The URL used to access the Apstra api.
+    type: str
+    required: false
+  verify_certificates:
+    description:
+      - If set to false, SSL certificates will not be verified.
+    type: bool
+    required: false
+    default: true
+  username:
+    description:
+      - The username for authentication.
+    type: str
+    required: false
+  password:
+    description:
+      - The password for authentication.
+    type: str
+    required: false
+  auth_token:
+    description:
+      - The authentication token to use if already authenticated.
+    type: str
+    required: false
   id:
     description:
       - Identifies the blueprint and optionally the floating IP node.
@@ -198,6 +212,18 @@ msg:
     returned: always
     type: str
 """
+
+import traceback
+import uuid
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    ApstraClientFactory,
+    apstra_client_module_args,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_virtual_network_id,
+)
 
 
 def _get_blueprint_client(client_factory, blueprint_id):

--- a/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/floating_ip.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024 Juniper Networks, Inc.
-# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/generic_systems.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/generic_systems.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/generic_systems.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/generic_systems.py
@@ -2,49 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-import time
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_system_node_id,
-)
-
-# SDK-based helpers (node read/write)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes import (
-    get_node as get_blueprint_node,
-    patch_node,
-    set_node_tags as set_blueprint_node_tags,
-    set_node_property as set_blueprint_node_property,
-)
-
-# SDK-based helpers (QE graph queries)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
-    run_qe_query,
-)
-
-# API-based helpers (raw_request — no SDK coverage)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_generic_systems import (
-    create_switch_system_links,
-    add_links_to_system,
-    delete_switch_system_links,
-    create_external_generic_system,
-    delete_external_generic_system,
-    get_system_asn,
-    set_system_asn,
-    get_system_loopback,
-    create_or_update_loopback,
-)
-
 
 DOCUMENTATION = """
 ---
@@ -83,7 +45,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -95,19 +56,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary identifying the generic system within a blueprint.
@@ -469,6 +427,45 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+import time
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_system_node_id,
+)
+
+# SDK-based helpers (node read/write)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes import (
+    get_node as get_blueprint_node,
+    patch_node,
+    set_node_tags as set_blueprint_node_tags,
+    set_node_property as set_blueprint_node_property,
+)
+
+# SDK-based helpers (QE graph queries)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+    run_qe_query,
+)
+
+# API-based helpers (raw_request — no SDK coverage)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_generic_systems import (
+    create_switch_system_links,
+    add_links_to_system,
+    delete_switch_system_links,
+    create_external_generic_system,
+    delete_external_generic_system,
+    get_system_asn,
+    set_system_asn,
+    get_system_loopback,
+    create_or_update_loopback,
+)
+
 
 # ──────────────────────────────────────────────────────────────────
 #  SDK-based system discovery helpers  (QE queries + node reads)

--- a/ansible_collections/juniper/apstra/plugins/modules/iba_probes.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/iba_probes.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/iba_probes.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/iba_probes.py
@@ -2,37 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.iba_probes import (
-    get_probe,
-    create_probe,
-    create_predefined_probe,
-    update_probe,
-    delete_probe,
-    find_probe_by_label,
-    list_predefined_probes,
-    get_predefined_probe,
-    get_dashboard,
-    create_dashboard,
-    update_dashboard,
-    delete_dashboard,
-    find_dashboard_by_label,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_probe_id,
-    resolve_dashboard_id,
-)
 
 DOCUMENTATION = """
 ---
@@ -60,7 +34,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -72,19 +45,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   type:
     description:
       - The type of IBA resource to manage.
@@ -442,6 +412,34 @@ predefined_probes:
   type: list
   returned: when state is present and type is predefined with no body
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.iba_probes import (
+    get_probe,
+    create_probe,
+    create_predefined_probe,
+    update_probe,
+    delete_probe,
+    find_probe_by_label,
+    list_predefined_probes,
+    get_predefined_probe,
+    get_dashboard,
+    create_dashboard,
+    update_dashboard,
+    delete_dashboard,
+    find_dashboard_by_label,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_probe_id,
+    resolve_dashboard_id,
+)
+
 
 # Read-only fields returned by the API but not part of the create/update body
 PROBE_READ_ONLY_FIELDS = (

--- a/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
@@ -2,36 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_interconnect_domain_id,
-    resolve_system_node_id,
-    resolve_virtual_network_id,
-    resolve_security_zone_id,
-    resolve_routing_policy_id,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_dci import (
-    patch_interconnect_domain_raw,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_interconnect_domain import (
-    get_interconnect_domain,
-    create_interconnect_domain,
-    update_interconnect_domain,
-    delete_interconnect_domain,
-    find_interconnect_domain_by_label,
-)
 
 DOCUMENTATION = """
 ---
@@ -61,7 +36,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -73,19 +47,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   type:
     description:
       - The type of interconnect resource to manage.
@@ -374,6 +345,32 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_interconnect_domain_id,
+    resolve_system_node_id,
+    resolve_virtual_network_id,
+    resolve_security_zone_id,
+    resolve_routing_policy_id,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_dci import (
+    patch_interconnect_domain_raw,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_interconnect_domain import (
+    get_interconnect_domain,
+    create_interconnect_domain,
+    update_interconnect_domain,
+    delete_interconnect_domain,
+    find_interconnect_domain_by_label,
+)
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -2,18 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
 
 DOCUMENTATION = """
 ---
@@ -44,7 +37,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -56,19 +48,16 @@ options:
       - The Apstra username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The Apstra password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Identifies the blueprint scope.
@@ -171,6 +160,14 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/os_upgrade.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/os_upgrade.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/os_upgrade.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/os_upgrade.py
@@ -2,27 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.upgrade import (
-    resolve_agent_id,
-    resolve_image_id,
-    list_blueprint_images,
-    list_blueprint_agent_ids,
-    trigger_upgrade,
-    get_upgrade_impact,
-    wait_for_upgrade_job,
-)
 
 DOCUMENTATION = """
 ---
@@ -49,7 +33,6 @@ options:
       - The URL used to access the Apstra API.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -61,19 +44,16 @@ options:
       - The Apstra username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The Apstra password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - A dict identifying the target blueprint and (for most states) device.
@@ -280,6 +260,23 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.upgrade import (
+    resolve_agent_id,
+    resolve_image_id,
+    list_blueprint_images,
+    list_blueprint_agent_ids,
+    trigger_upgrade,
+    get_upgrade_impact,
+    wait_for_upgrade_job,
+)
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/property_set.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/property_set.py
@@ -2,25 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_property_set import (
-    reimport_blueprint_property_set,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_property_set_id,
-)
 
 DOCUMENTATION = """
 ---
@@ -53,7 +39,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -65,19 +50,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing identifiers for the property set.
@@ -324,6 +306,21 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_property_set import (
+    reimport_blueprint_property_set,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_property_set_id,
+)
 
 
 def _reimport_blueprint_property_set(

--- a/ansible_collections/juniper/apstra/plugins/modules/property_set.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/property_set.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/resource_group.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/resource_group.py
@@ -2,23 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_pool_ids,
-    resolve_resource_group_name,
-)
 
 DOCUMENTATION = """
 ---
@@ -35,7 +23,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -47,19 +34,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing the blueprint and resource group IDs.
@@ -157,6 +141,19 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_pool_ids,
+    resolve_resource_group_name,
+)
 
 
 def main():

--- a/ansible_collections/juniper/apstra/plugins/modules/resource_group.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/resource_group.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/resource_pools.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/resource_pools.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/resource_pools.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/resource_pools.py
@@ -2,20 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import ipaddress
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
 
 DOCUMENTATION = """
 ---
@@ -38,7 +29,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -50,19 +40,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   type:
     description:
       - The type of resource pool to manage.
@@ -546,6 +533,17 @@ msg:
   type: str
   returned: always
 """
+
+import ipaddress
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+
 
 # Map pool type to the object type used by the client
 POOL_TYPE_MAP = {

--- a/ansible_collections/juniper/apstra/plugins/modules/rollback.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/rollback.py
@@ -2,18 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
 
 DOCUMENTATION = """
 ---
@@ -37,7 +30,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -49,19 +41,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing the blueprint ID.
@@ -144,6 +133,14 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
 
 
 def main():

--- a/ansible_collections/juniper/apstra/plugins/modules/rollback.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/rollback.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/routing_policy.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/routing_policy.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/routing_policy.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/routing_policy.py
@@ -2,19 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
 
 DOCUMENTATION = """
 ---
@@ -31,7 +23,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -43,19 +34,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing the blueprint and routing policy IDs.
@@ -69,6 +57,8 @@ options:
   tags:
     description:
       - List of tags to apply to the routing policy.
+    type: list
+    elements: str
   state:
     description:
       - Desired state of the routing policy.
@@ -168,6 +158,15 @@ msg:
   returned: always
 """
 
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+
 
 def main():
     object_module_args = dict(
@@ -176,7 +175,7 @@ def main():
         state=dict(
             type="str", required=False, choices=["present", "absent"], default="present"
         ),
-        tags=dict(type="list", required=False),
+        tags=dict(type="list", elements="str", required=False),
     )
     client_module_args = apstra_client_module_args()
     module_args = client_module_args | object_module_args

--- a/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
@@ -2,28 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_security_zone_id,
-    resolve_vrf_interface_pair,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes import (
-    get_node,
-    patch_node,
-    node_needs_update,
-)
 
 DOCUMENTATION = """
 ---
@@ -45,7 +28,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -57,19 +39,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing the blueprint and security zone IDs.
@@ -83,6 +62,8 @@ options:
   tags:
     description:
       - List of tags to apply to the security zone.
+    type: list
+    elements: str
   state:
     description:
       - Desired state of the security zone.
@@ -182,6 +163,24 @@ msg:
   returned: always
 """
 
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_security_zone_id,
+    resolve_vrf_interface_pair,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes import (
+    get_node,
+    patch_node,
+    node_needs_update,
+)
+
 
 def _apply_interface_ip_assignments(
     client_factory, blueprint_id, sz_id, assignments, result
@@ -245,7 +244,7 @@ def main():
         state=dict(
             type="str", required=False, choices=["present", "absent"], default="present"
         ),
-        tags=dict(type="list", required=False),
+        tags=dict(type="list", elements="str", required=False),
     )
     client_module_args = apstra_client_module_args()
     module_args = client_module_args | object_module_args

--- a/ansible_collections/juniper/apstra/plugins/modules/system_agents.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/system_agents.py
@@ -2,19 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-import time
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
 
 DOCUMENTATION = """
 ---
@@ -43,7 +35,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -55,19 +46,16 @@ options:
       - The Apstra username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The Apstra password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - A dict identifying an existing system agent.
@@ -127,7 +115,6 @@ options:
           - The password for authenticating to the managed device.
         type: str
         required: false
-        no_log: true
       platform:
         description:
           - The device platform/OS family.
@@ -378,6 +365,15 @@ acknowledged_systems:
   elements: str
   returned: when state=acknowledged
 """
+
+import traceback
+import time
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/system_agents.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/system_agents.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/tag.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/tag.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/tag.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/tag.py
@@ -2,19 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
 
 DOCUMENTATION = """
 ---
@@ -31,7 +23,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -43,19 +34,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing the blueprint and tag IDs.
@@ -138,6 +126,15 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
 
 
 def main():

--- a/ansible_collections/juniper/apstra/plugins/modules/upgrade_group.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/upgrade_group.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/upgrade_group.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/upgrade_group.py
@@ -2,26 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.upgrade import (
-    list_all_systems,
-    get_group_members,
-    resolve_device_key,
-    set_upgrade_group,
-    get_upgrade_impact,
-    _build_system_id_to_agent_map,
-)
 
 DOCUMENTATION = """
 ---
@@ -50,7 +35,6 @@ options:
     description: The URL used to access the Apstra API.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description: If false, SSL certificates are not verified.
     type: bool
@@ -60,17 +44,14 @@ options:
     description: Apstra username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description: Apstra password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description: Authentication token (if already authenticated).
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Identifies the upgrade group to operate on.
@@ -389,6 +370,23 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.upgrade import (
+    list_all_systems,
+    get_group_members,
+    resolve_device_key,
+    set_upgrade_group,
+    get_upgrade_impact,
+    _build_system_id_to_agent_map,
+)
+
 
 _DEFAULT_GROUP = "default"
 

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
@@ -2,37 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_virtual_infra_manager_id,
-    resolve_vim_agent_and_system_id,
-    resolve_security_zone_id,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.vim_vcenter import (
-    list_vim_vcenters,
-    create_vim_vcenter,
-    get_vim_vcenter,
-    update_vim_vcenter,
-    patch_vim_vcenter,
-    delete_vim_vcenter,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.vim_blueprint_utils import (
-    resolve_blueprint_virtual_infra_anomalies,
-    query_blueprint_vms,
-    get_blueprint_vnet,
-)
 
 DOCUMENTATION = """
 ---
@@ -65,7 +39,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -77,19 +50,16 @@ options:
       - The Apstra username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The Apstra password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing identifiers.
@@ -517,6 +487,33 @@ resolved_from_vim_ip:
   type: dict
   returned: when body.vim_ip is provided (blueprint scope)
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_virtual_infra_manager_id,
+    resolve_vim_agent_and_system_id,
+    resolve_security_zone_id,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.vim_vcenter import (
+    list_vim_vcenters,
+    create_vim_vcenter,
+    get_vim_vcenter,
+    update_vim_vcenter,
+    patch_vim_vcenter,
+    delete_vim_vcenter,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.vim_blueprint_utils import (
+    resolve_blueprint_virtual_infra_anomalies,
+    query_blueprint_vms,
+    get_blueprint_vnet,
+)
 
 
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -2,24 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-    singular_leaf_object_type,
-)
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
-    resolve_system_node_id,
-    resolve_security_zone_id,
-    resolve_esi_member_ids,
-)
 
 DOCUMENTATION = """
 ---
@@ -41,7 +28,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -53,19 +39,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing the blueprint and virtual network IDs.
@@ -79,6 +62,8 @@ options:
   tags:
     description:
       - List of tags to apply to the virtual network.
+    type: list
+    elements: str
   state:
     description:
       - Desired state of the virtual network.
@@ -229,6 +214,20 @@ msg:
   returned: always
 """
 
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+    singular_leaf_object_type,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+    resolve_system_node_id,
+    resolve_security_zone_id,
+    resolve_esi_member_ids,
+)
+
 
 def main():
     object_module_args = dict(
@@ -237,7 +236,7 @@ def main():
         state=dict(
             type="str", required=False, choices=["present", "absent"], default="present"
         ),
-        tags=dict(type="list", required=False),
+        tags=dict(type="list", elements="str", required=False),
     )
     client_module_args = apstra_client_module_args()
     module_args = client_module_args | object_module_args

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/ztp_device.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/ztp_device.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
 
 from __future__ import absolute_import, division, print_function
 

--- a/ansible_collections/juniper/apstra/plugins/modules/ztp_device.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/ztp_device.py
@@ -2,18 +2,11 @@
 # -*- coding: utf-8 -*-
 
 # Copyright (c) 2024, Juniper Networks
-# BSD 3-Clause License
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
-import traceback
-
-from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
-    apstra_client_module_args,
-    ApstraClientFactory,
-)
 
 DOCUMENTATION = """
 ---
@@ -45,7 +38,6 @@ options:
       - The URL used to access the Apstra api.
     type: str
     required: false
-    default: APSTRA_API_URL environment variable
   verify_certificates:
     description:
       - If set to false, SSL certificates will not be verified.
@@ -57,19 +49,16 @@ options:
       - The username for authentication.
     type: str
     required: false
-    default: APSTRA_USERNAME environment variable
   password:
     description:
       - The password for authentication.
     type: str
     required: false
-    default: APSTRA_PASSWORD environment variable
   auth_token:
     description:
       - The authentication token to use if already authenticated.
     type: str
     required: false
-    default: APSTRA_AUTH_TOKEN environment variable
   id:
     description:
       - Dictionary containing the ZTP device identifier.
@@ -188,6 +177,14 @@ msg:
   type: str
   returned: always
 """
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
 
 
 def _get_ztp_device_client(client_factory):

--- a/ansible_collections/juniper/apstra/tests/sanity/ignore-2.16.txt
+++ b/ansible_collections/juniper/apstra/tests/sanity/ignore-2.16.txt
@@ -1,0 +1,33 @@
+# The repo is licensed under Apache-2.0 (see LICENSE).
+# ansible-test mandates a GPLv3 header for the missing-gplv3-license check,
+# but Ansible Galaxy/Automation Hub certification does not require it and the
+# project intentionally keeps the Apache-2.0 header to match the repo license.
+plugins/modules/apstra_facts.py validate-modules:missing-gplv3-license
+plugins/modules/authenticate.py validate-modules:missing-gplv3-license
+plugins/modules/blueprint.py validate-modules:missing-gplv3-license
+plugins/modules/cabling_map.py validate-modules:missing-gplv3-license
+plugins/modules/configlets.py validate-modules:missing-gplv3-license
+plugins/modules/connectivity_template.py validate-modules:missing-gplv3-license
+plugins/modules/connectivity_template_assignment.py validate-modules:missing-gplv3-license
+plugins/modules/design.py validate-modules:missing-gplv3-license
+plugins/modules/endpoint_policy.py validate-modules:missing-gplv3-license
+plugins/modules/external_gateway.py validate-modules:missing-gplv3-license
+plugins/modules/fabric_settings.py validate-modules:missing-gplv3-license
+plugins/modules/floating_ip.py validate-modules:missing-gplv3-license
+plugins/modules/generic_systems.py validate-modules:missing-gplv3-license
+plugins/modules/iba_probes.py validate-modules:missing-gplv3-license
+plugins/modules/interconnect_gateway.py validate-modules:missing-gplv3-license
+plugins/modules/interface_map.py validate-modules:missing-gplv3-license
+plugins/modules/os_upgrade.py validate-modules:missing-gplv3-license
+plugins/modules/property_set.py validate-modules:missing-gplv3-license
+plugins/modules/resource_group.py validate-modules:missing-gplv3-license
+plugins/modules/resource_pools.py validate-modules:missing-gplv3-license
+plugins/modules/rollback.py validate-modules:missing-gplv3-license
+plugins/modules/routing_policy.py validate-modules:missing-gplv3-license
+plugins/modules/security_zone.py validate-modules:missing-gplv3-license
+plugins/modules/system_agents.py validate-modules:missing-gplv3-license
+plugins/modules/tag.py validate-modules:missing-gplv3-license
+plugins/modules/upgrade_group.py validate-modules:missing-gplv3-license
+plugins/modules/virtual_infra_manager.py validate-modules:missing-gplv3-license
+plugins/modules/virtual_network.py validate-modules:missing-gplv3-license
+plugins/modules/ztp_device.py validate-modules:missing-gplv3-license

--- a/ansible_collections/juniper/apstra/tests/sanity/ignore-2.17.txt
+++ b/ansible_collections/juniper/apstra/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,1 @@
+ignore-2.16.txt

--- a/ansible_collections/juniper/apstra/tests/sanity/ignore-2.18.txt
+++ b/ansible_collections/juniper/apstra/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,1 @@
+ignore-2.16.txt

--- a/ansible_collections/juniper/apstra/tests/sanity/ignore-2.19.txt
+++ b/ansible_collections/juniper/apstra/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,1 @@
+ignore-2.16.txt


### PR DESCRIPTION
…ll modules  Systematic fixes (all 29 modules): - Replace BSD/MIT license with GPL v3.0+ (Ansible Galaxy requirement) - Remove spurious 'default: APSTRA_XXX environment variable' doc entries   (argument_spec has default=None; env-var note moved to description) - Move regular imports to after DOCUMENTATION/EXAMPLES/RETURN   (import-before-documentation sanity check)  Module-specific fixes: - authenticate.py: fix DOCUMENTATION.module 'apstra_authenticate' -> 'authenticate' - apstra_facts.py: remove invalid env: blocks; fix gather_network_facts   required: true -> false; fix filter default string -> dict - blueprint.py: document undocumented 'unlock' parameter - design.py: document missing 'username' and 'password' parameters - floating_ip.py: add standard auth params to DOCUMENTATION - system_agents.py: remove invalid no_log: true from suboptions DOCUMENTATION - endpoint_policy, routing_policy, security_zone, virtual_network:   add elements: str to 'tags' argument_spec and DOCUMENTATION  Result: ansible-test sanity --test validate-modules exits 0 (was 196 errors)