### PR TITLE
Address RedHat Automation Hub certification follow-up items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ $(APSTRA_COLLECTION_ROOT)/.apstra-collection: $(APSTRA_COLLECTION_ROOT)/requirem
 	touch "$@"
 
 $(APSTRA_COLLECTION_ROOT)/requirements.txt: Pipfile Makefile pipenv
-	pipenv clean && pipenv requirements --from-pipfile --exclude-markers | sed -e 's:==:>=:' | sed -e '\:build/wheels/aos_sdk:d' > "$@"
+	pipenv clean && pipenv requirements --from-pipfile --exclude-markers | sed -e 's:==:>=:' | sed -e '\:build/wheels/aos_sdk:d' | sed -e '\:ansible-core:d' > "$@"
 
 install: build
 	pipenv run ansible-galaxy collection install --ignore-certs --force $(APSTRA_COLLECTION)

--- a/ansible_collections/juniper/apstra/README.md
+++ b/ansible_collections/juniper/apstra/README.md
@@ -8,6 +8,8 @@ This repository contains the Juniper Apstra Ansible Collection, which provides a
 
 As a Red Hat Ansible [Certified Content](https://catalog.redhat.com/software/search?target_platforms=Red%20Hat%20Ansible%20Automation%20Platform), this collection is entitled to [support](https://access.redhat.com/support/) through [Ansible Automation Platform](https://www.redhat.com/en/technologies/management/ansible) (AAP).
 
+If you are a Red Hat customer using this collection via Ansible Automation Hub, please open a support case using the [Create Issue](https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12323322&issuetype=1&components=12347507) link in Automation Hub.
+
 If a support case cannot be opened with Red Hat and the collection has been obtained either from [Galaxy](https://galaxy.ansible.com/ui/) or [GitHub](https://github.com/Juniper/apstra-ansible-collection/issues), there is community support available at no charge.
 
 You can join us on [#network:ansible.com](https://matrix.to/#/#network:ansible.com) room or the [Ansible Forum Network Working Group](https://forum.ansible.com/g/network-wg).

--- a/ansible_collections/juniper/apstra/galaxy.yml
+++ b/ansible_collections/juniper/apstra/galaxy.yml
@@ -27,3 +27,4 @@ build_ignore:
     - conf.py
     - _build
     - .gitignore
+    - .ansible-lint

--- a/ansible_collections/juniper/apstra/meta/runtime.yml
+++ b/ansible_collections/juniper/apstra/meta/runtime.yml
@@ -1,1 +1,1 @@
-requires_ansible: ">=2.15.0"
+requires_ansible: ">=2.16.0"


### PR DESCRIPTION
- Makefile: exclude ansible-core from generated requirements.txt (prevents re-introduction of ansible-core on next 'make build')
- galaxy.yml: add .ansible-lint to build_ignore list (excludes lint config from published tarball)
- meta/runtime.yml: update requires_ansible from >=2.15.0 to >=2.16.0
- README.md: add Automation Hub 'Create Issue' link to support section