### PR TITLE
Fix Ansible certification sanity failures and lint errors

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -883,7 +883,7 @@ def resolve_vrf_interface_pair(client_factory, blueprint_id, sz_id, interface_re
             f".node('interface', if_name='{if_name}', name='ep1')"
         )
     else:
-        q += ".out('composed_of')" f".node('interface', name='ep1')"
+        q += ".out('composed_of')" ".node('interface', name='ep1')"
 
     q += (
         f".in_().node('sz_instance', name='szi')"

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -371,8 +371,8 @@ EXAMPLES = """
     assignment:
       spine1: "SERIAL001"
       spine2: "SERIAL002"
-      leaf1:  "SERIAL003"
-      leaf2:  "SERIAL004"
+      leaf1: "SERIAL003"
+      leaf2: "SERIAL004"
     deploy_mode: deploy
     state: node_updated
   register: assigned

--- a/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/connectivity_template_assignment.py
@@ -393,7 +393,7 @@ def main():
             ep_client, blueprint_id, ct_id
         )
 
-        # ── Validate resolved IDs against the CT’s application-points tree ──
+        # -- Validate resolved IDs against the CT's application-points tree --
         invalid_ids = [i for i in application_point_ids if i not in valid_ap_ids]
         if invalid_ids:
             # Build a human-readable representation for each invalid ID.

--- a/ansible_collections/juniper/apstra/plugins/modules/upgrade_group.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/upgrade_group.py
@@ -281,8 +281,8 @@ EXAMPLES = """
 
 - name: Build per-OS agent lists
   ansible.builtin.set_fact:
-    junos_keys:     "{{ grp.groups['mixed-spines'] | selectattr('os_variant', 'ne', 'qfx-ms-fixed') | map(attribute='device_key') | list }}"
-    evo_keys:       "{{ grp.groups['mixed-spines'] | selectattr('os_variant', 'equalto', 'qfx-ms-fixed') | map(attribute='device_key') | list }}"
+    junos_keys: "{{ grp.groups['mixed-spines'] | selectattr('os_variant', 'ne', 'qfx-ms-fixed') | map(attribute='device_key') | list }}"
+    evo_keys: "{{ grp.groups['mixed-spines'] | selectattr('os_variant', 'equalto', 'qfx-ms-fixed') | map(attribute='device_key') | list }}"
 
 - name: Upgrade JunOS devices
   juniper.apstra.os_upgrade:

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
@@ -425,7 +425,8 @@ EXAMPLES = """
 
 - name: Show vnet
   ansible.builtin.debug:
-    var: vnet_info.vnet"""
+    var: vnet_info.vnet
+"""
 
 RETURN = """
 changed:

--- a/ansible_collections/juniper/apstra/tests/floating_ip.yml
+++ b/ansible_collections/juniper/apstra/tests/floating_ip.yml
@@ -24,7 +24,7 @@
           blueprint: "{{ blueprint_name }}"
         state: absent
         auth_token: "{{ auth.token }}"
-      ignore_errors: true
+      failed_when: false
 
     - name: Create blueprint
       juniper.apstra.blueprint:

--- a/ansible_collections/juniper/apstra/tests/generic_systems.yml
+++ b/ansible_collections/juniper/apstra/tests/generic_systems.yml
@@ -293,7 +293,7 @@
           name: "test-gs-tf-001-updated"
         state: absent
         auth_token: "{{ auth.token }}"
-      ignore_errors: true
+      failed_when: false
 
     - name: "Cleanup stale GS (test-gs-tf-001) if present"
       juniper.apstra.generic_systems:
@@ -303,7 +303,7 @@
           name: "test-gs-tf-001"
         state: absent
         auth_token: "{{ auth.token }}"
-      ignore_errors: true
+      failed_when: false
 
     # ══════════════════════════════════════════════════════════════════
     #  TEST 1: Create generic system with a single link
@@ -565,7 +565,7 @@
           name: "test-gs-name-res"
         state: absent
         auth_token: "{{ auth.token }}"
-      ignore_errors: true
+      failed_when: false
       when: not use_existing_blueprint | bool
 
     - name: "TEST 8b - Create GS using leaf label (name resolution)"
@@ -614,7 +614,7 @@
           name: "test-lag-server-tf"
         state: absent
         auth_token: "{{ auth.token }}"
-      ignore_errors: true
+      failed_when: false
 
     # ══════════════════════════════════════════════════════════════════
     #  TEST 9: Create generic system with dual LAG links
@@ -738,7 +738,7 @@
           name: "test-pc-id-gs-tf"
         state: absent
         auth_token: "{{ auth.token }}"
-      ignore_errors: true
+      failed_when: false
 
     - name: "TEST 11b - Create LAG GS with port_channel_id_min=30 port_channel_id_max=30"
       juniper.apstra.generic_systems:
@@ -874,7 +874,7 @@
           name: "test-ext-gs-tf-updated"
         state: absent
         auth_token: "{{ auth.token }}"
-      ignore_errors: true
+      failed_when: false
 
     - name: "Cleanup stale external GS (test-ext-gs-tf) if present"
       juniper.apstra.generic_systems:
@@ -884,7 +884,7 @@
           name: "test-ext-gs-tf"
         state: absent
         auth_token: "{{ auth.token }}"
-      ignore_errors: true
+      failed_when: false
 
     # ══════════════════════════════════════════════════════════════════
     #  TEST 12: Create external generic system
@@ -1114,7 +1114,7 @@
         state: present
         auth_token: "{{ auth.token }}"
       register: no_links_result
-      ignore_errors: true
+      failed_when: false
 
     - name: Verify missing links error
       ansible.builtin.assert:
@@ -1140,7 +1140,7 @@
         state: present
         auth_token: "{{ auth.token }}"
       register: dup_links_result
-      ignore_errors: true
+      failed_when: false
 
     - name: Verify duplicate link error
       ansible.builtin.assert:

--- a/ansible_collections/juniper/apstra/tests/os_upgrade.yml
+++ b/ansible_collections/juniper/apstra/tests/os_upgrade.yml
@@ -323,8 +323,8 @@
         msg:
           - "Test 1 (gathered):               {{ 'PASSED' if not t1.failed | default(false) else 'FAILED' }}"
           - "Test 2 (gathered idempotent):     {{ 'PASSED' if not t2.failed | default(false) else 'FAILED' }}"
-          - "Test 3 (impact_report all):       {{ 'PASSED' if not t3.failed | default(false) else ('SKIPPED (6.1+ required)' if 'HTTP' in (t3.msg | default('')) or 'upgrade' in (t3.msg | default('')) | lower else 'FAILED') }}"
-          - "Test 4 (impact_report single):    {{ 'SKIPPED (6.1+ required)' if t3.failed | default(false) else ('PASSED' if not t4.failed | default(false) else 'FAILED') }}"
+          - "Test 3 (impact_report all):       {{ 'PASSED' if not t3.failed | default(false) else ('SKIPPED (6.1+ required)' if 'HTTP' in (t3.msg | default('')) or 'upgrade' in (t3.msg | default('')) | lower else 'FAILED') }}" # noqa: yaml[line-length]
+          - "Test 4 (impact_report single):    {{ 'SKIPPED (6.1+ required)' if t3.failed | default(false) else ('PASSED' if not t4.failed | default(false) else 'FAILED') }}" # noqa: yaml[line-length]
           - "Test 5 (present no system):       {{ 'PASSED' if t5.failed | default(false) else 'FAILED' }}"
           - "Test 6 (present no image):        {{ 'PASSED' if t6.failed | default(false) else 'FAILED' }}"
           - "Test 7 (present bad image):       {{ 'PASSED' if t7.failed | default(false) else 'FAILED' }}"

--- a/ansible_collections/juniper/apstra/tests/sanity/ignore-2.16.txt
+++ b/ansible_collections/juniper/apstra/tests/sanity/ignore-2.16.txt
@@ -1,7 +1,3 @@
-# The repo is licensed under Apache-2.0 (see LICENSE).
-# ansible-test mandates a GPLv3 header for the missing-gplv3-license check,
-# but Ansible Galaxy/Automation Hub certification does not require it and the
-# project intentionally keeps the Apache-2.0 header to match the repo license.
 plugins/modules/apstra_facts.py validate-modules:missing-gplv3-license
 plugins/modules/authenticate.py validate-modules:missing-gplv3-license
 plugins/modules/blueprint.py validate-modules:missing-gplv3-license

--- a/ansible_collections/juniper/apstra/tests/system_agents.yml
+++ b/ansible_collections/juniper/apstra/tests/system_agents.yml
@@ -41,7 +41,7 @@
           management_ip: "{{ test_management_ip }}"
         auth_token: "{{ auth.token }}"
         state: absent
-      ignore_errors: true
+      failed_when: false
 
     # ── Test 1: Create agent ──────────────────────────────────────
     - name: "Test 1: Create system agent"

--- a/ansible_collections/juniper/apstra/tests/test_axis_os_upgrade.yml
+++ b/ansible_collections/juniper/apstra/tests/test_axis_os_upgrade.yml
@@ -125,7 +125,7 @@
     ########################################################################
     # Phase 4 — state=present: ACTUAL UPGRADE (disabled by default)
     ########################################################################
-    - name: "Phase 4 — ⚠️ UPGRADE {{ upgrade_device }} to {{ upgrade_image }}"
+    - name: "Phase 4 — Upgrade device to image: {{ upgrade_device }} => {{ upgrade_image }}"
       juniper.apstra.os_upgrade:
         id:
           blueprint: "{{ blueprint_label }}"
@@ -166,4 +166,4 @@
           - "Phase 1 (gathered):           PASSED — {{ p1.images | length }} image(s)"
           - "Phase 2 (impact all):         {{ 'PASSED — ' ~ (p2.agent_ids | default([]) | length) ~ ' agents' if not p2.failed | default(false) else 'FAILED' }}"
           - "Phase 3 (impact single):      {{ 'PASSED' if single_agent is defined and not p3.failed | default(false) else 'SKIPPED' }}"
-          - "Phase 4 (upgrade):            {{ 'PASSED' if p4 is defined and p4 is not skipped and not p4.failed | default(false) else 'SKIPPED (disabled)' }}"
+          - "Phase 4 (upgrade):            {{ 'PASSED' if p4 is defined and p4 is not skipped and not p4.failed | default(false) else 'SKIPPED (disabled)' }}" # noqa: yaml[line-length]

--- a/ansible_collections/juniper/apstra/tests/test_axis_upgrade_group.yml
+++ b/ansible_collections/juniper/apstra/tests/test_axis_upgrade_group.yml
@@ -75,7 +75,7 @@
         ######################################################################
         # Test 1 — state=present: create test group with 2 devices
         ######################################################################
-        - name: "Test 1 — Create '{{ test_group_name }}' with 2 devices"
+        - name: "Test 1 — Create upgrade group: {{ test_group_name }}"
           juniper.apstra.upgrade_group:
             id:
               name: "{{ test_group_name }}"

--- a/ansible_collections/juniper/apstra/tests/virtual_infra_manager.yml
+++ b/ansible_collections/juniper/apstra/tests/virtual_infra_manager.yml
@@ -148,7 +148,7 @@
           retries: 12
           delay: 5
           when: vcenter_hostname is defined and vcenter_hostname not in ['192.0.2.1', '']
-          ignore_errors: true
+          failed_when: false
           tags: [phase1]
 
         - name: "Test 1b: Display VIM connection state after create"
@@ -331,7 +331,7 @@
           retries: 12
           delay: 5
           when: vcenter_hostname is defined and vcenter_hostname not in ['192.0.2.1', '']
-          ignore_errors: true
+          failed_when: false
           tags: [phase2]
 
         - name: "Phase 2 setup: display VIM connection status"
@@ -401,7 +401,7 @@
             state: present
             auth_token: "{{ auth.token }}"
           register: vc_created
-          ignore_errors: true
+          failed_when: false
           tags: [phase2]
 
         - name: "Test 4c result"
@@ -431,7 +431,7 @@
             auth_token: "{{ auth.token }}"
           register: vc_get
           when: vcenter_id is defined and vcenter_id != ''
-          ignore_errors: true
+          failed_when: false
           tags: [phase2]
 
         - name: "Test 4d result"
@@ -455,7 +455,7 @@
             auth_token: "{{ auth.token }}"
           register: vc_patch
           when: vcenter_id is defined and vcenter_id != ''
-          ignore_errors: true
+          failed_when: false
           tags: [phase2]
 
         - name: "Test 4e result"
@@ -477,7 +477,7 @@
             auth_token: "{{ auth.token }}"
           register: vc_delete
           when: vcenter_id is defined and vcenter_id != ''
-          ignore_errors: true
+          failed_when: false
           tags: [phase2]
 
         - name: "Test 4f result"
@@ -567,7 +567,7 @@
             auth_token: "{{ auth.token }}"
           register: bp_vim_assign
           when: vim_id is defined and vim_system_id is defined
-          ignore_errors: true
+          failed_when: false
           tags: [phase3]
 
         - name: Verify blueprint VIM assignment
@@ -594,7 +594,7 @@
             state: present
             auth_token: "{{ auth.token }}"
           register: anomaly_result
-          ignore_errors: true
+          failed_when: false
           tags: [phase3]
 
         - name: Verify anomaly resolver result
@@ -620,7 +620,7 @@
             state: present
             auth_token: "{{ auth.token }}"
           register: vm_query_result
-          ignore_errors: true
+          failed_when: false
           tags: [phase3]
 
         - name: Verify query_vm result
@@ -646,7 +646,7 @@
             state: present
             auth_token: "{{ auth.token }}"
           register: vnet_result
-          ignore_errors: true
+          failed_when: false
           tags: [phase3]
 
         - name: Verify vnet result
@@ -723,7 +723,7 @@
             state: absent
             auth_token: "{{ auth.token }}"
           when: vim_id is defined
-          ignore_errors: true
+          failed_when: false
           tags: [phase1, phase2, teardown]
 
         - name: Delete test blueprint if it was created
@@ -734,7 +734,7 @@
             auth_token: "{{ auth.token }}"
             state: absent
           when: blueprint_id is defined
-          ignore_errors: true
+          failed_when: false
           tags: [phase3, teardown]
 
     # ── Summary ───────────────────────────────────────────────────


### PR DESCRIPTION
Fixes 3 ansible-test sanity failures:
- tests/sanity/ignore-2.16.txt: remove leading comment lines (ignores test forbids comments/blank lines)
- connectivity_template_assignment.py: replace Unicode right-single-quote (U+2019) with ASCII apostrophe (no-smart-quotes)
- name_resolution.py: remove f prefix from f-string with no interpolation (pylint f-string-without-interpolation)

Fixes ansible-lint errors reported in certification import log:
- blueprint.py, upgrade_group.py: remove extra alignment spaces after colons in EXAMPLES YAML (yaml[colons])
- virtual_infra_manager.py: add missing newline before closing EXAMPLES triple-quote (yaml[new-line-at-end-of-file])
- floating_ip.yml, system_agents.yml, virtual_infra_manager.yml, generic_systems.yml: replace ignore_errors: true with failed_when: false (ansible-lint ignore-errors rule)
- test_axis_os_upgrade.yml, test_axis_upgrade_group.yml: restructure task names to move Jinja templates to end (name[template])
- os_upgrade.yml, test_axis_os_upgrade.yml: add noqa yaml[line-length] to unavoidably long debug message lines