### PR TITLE
feat: keyword expansion for bound_to system_id

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/client.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/client.py
@@ -313,21 +313,39 @@ def _dict_subset_equal(current, desired):
 def _lists_match(current, desired):
     """Return True when *current* and *desired* lists are semantically equal.
 
-    For lists of dicts, compare using subset matching per position: each
-    desired entry is checked against the corresponding current entry using
-    only the keys the user specified (see :func:`_dict_subset_equal`).
+    For lists of dicts, use **order-independent** subset matching: each
+    desired entry must find exactly one unmatched current entry whose
+    user-specified keys all match (see :func:`_dict_subset_equal`).  This
+    means lists like ``bound_to`` compare correctly even when the Apstra
+    API returns entries in a different order than the playbook.
 
-    For lists of scalars (strings, ints, bools), fall back to exact equality.
+    For lists of scalars (strings, ints, bools), fall back to exact
+    positional equality.
     """
     if len(current) != len(desired):
         return False
-    for cur_item, des_item in zip(current, desired):
-        if isinstance(des_item, dict) and isinstance(cur_item, dict):
-            if not _dict_subset_equal(cur_item, des_item):
+    # Determine whether this is a list of dicts
+    if any(isinstance(item, dict) for item in desired):
+        # Order-independent matching: each desired item must consume exactly
+        # one unmatched current item via subset equality.
+        available = list(current)
+        for des_item in desired:
+            matched = False
+            for i, cur_item in enumerate(available):
+                if isinstance(cur_item, dict) and isinstance(des_item, dict):
+                    if _dict_subset_equal(cur_item, des_item):
+                        available.pop(i)
+                        matched = True
+                        break
+                elif cur_item == des_item:
+                    available.pop(i)
+                    matched = True
+                    break
+            if not matched:
                 return False
-        elif cur_item != des_item:
-            return False
-    return True
+        return True
+    # Scalar list: exact positional match
+    return current == desired
 
 
 class ApstraClientFactory:

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/client.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/client.py
@@ -286,6 +286,50 @@ def _blueprint_lock_tag_name(blueprint_id):
     return "blueprint {} locked".format(blueprint_id)
 
 
+def _dict_subset_equal(current, desired):
+    """Return True if all keys in *desired* exist in *current* with equal values.
+
+    API responses often include extra computed/read-only fields (e.g.
+    ``access_switch_node_ids``, ``tagged_ct_id``) that the user never
+    specifies.  This function compares only the keys the user provided,
+    so those extra fields do not trigger spurious changes.
+    """
+    for key, desired_value in desired.items():
+        current_value = current.get(key)
+        if isinstance(desired_value, dict) and isinstance(current_value, dict):
+            if not _dict_subset_equal(current_value, desired_value):
+                return False
+        elif isinstance(desired_value, list) and current_value is None:
+            if desired_value:
+                return False
+        elif isinstance(desired_value, list) and isinstance(current_value, list):
+            if not _lists_match(current_value, desired_value):
+                return False
+        elif current_value != desired_value:
+            return False
+    return True
+
+
+def _lists_match(current, desired):
+    """Return True when *current* and *desired* lists are semantically equal.
+
+    For lists of dicts, compare using subset matching per position: each
+    desired entry is checked against the corresponding current entry using
+    only the keys the user specified (see :func:`_dict_subset_equal`).
+
+    For lists of scalars (strings, ints, bools), fall back to exact equality.
+    """
+    if len(current) != len(desired):
+        return False
+    for cur_item, des_item in zip(current, desired):
+        if isinstance(des_item, dict) and isinstance(cur_item, dict):
+            if not _dict_subset_equal(cur_item, des_item):
+                return False
+        elif cur_item != des_item:
+            return False
+    return True
+
+
 class ApstraClientFactory:
     """
     Factory class to create and manage Apstra clients.
@@ -942,7 +986,9 @@ class ApstraClientFactory:
         tag = tags_client.blueprints[id].tags.get(label=_blueprint_lock_tag_name(id))
         return tag is not None
 
-    def commit_blueprint(self, id, timeout=DEFAULT_BLUEPRINT_COMMIT_TIMEOUT, description=None):
+    def commit_blueprint(
+        self, id, timeout=DEFAULT_BLUEPRINT_COMMIT_TIMEOUT, description=None
+    ):
         """
         Commit the blueprint with the given ID.
 
@@ -1138,8 +1184,21 @@ class ApstraClientFactory:
                     changes[key] = nested_changes
                     changed = True
             elif isinstance(desired_value, list) and isinstance(current_value, list):
-                # Compare lists
-                if current_value != desired_value:
+                # Compare lists.  For lists of dicts, use subset matching:
+                # each desired entry is compared against the corresponding
+                # current entry using only the keys the user specified.
+                # This prevents API-injected fields (e.g. 'access_switch_node_ids'
+                # in bound_to entries) from causing spurious changes.
+                # For lists of scalars, fall back to exact equality.
+                if not _lists_match(current_value, desired_value):
+                    current[key] = desired_value
+                    changes[key] = desired_value
+                    changed = True
+            elif isinstance(desired_value, list) and current_value is None:
+                # Treat None (API-returned) as equivalent to an empty list.
+                # If the user provides [] and the API returns null/None, that
+                # is semantically identical — no update needed.
+                if desired_value:
                     current[key] = desired_value
                     changes[key] = desired_value
                     changed = True

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -621,6 +621,42 @@ def resolve_rg_node_id(client_factory, blueprint_id, node_ref):
     return None
 
 
+def collapse_to_rg_if_applicable(client_factory, blueprint_id, system_ids):
+    """If *system_ids* exactly match the full membership of one RG, return
+    that RG's node ID.  Otherwise return ``None`` (use individual IDs).
+
+    When a tag or role keyword expands to individual system IDs that
+    together form an ESI/MLAG redundancy group, Apstra collapses them to
+    the RG node ID in GET responses.  Sending the individual IDs in
+    POST/PATCH always triggers a mismatch on the next run.  This helper
+    detects the pattern and returns the canonical RG node ID so the
+    desired state matches what GET returns.
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param blueprint_id: The blueprint UUID.
+    :param system_ids: A list of system node IDs returned by keyword expansion.
+    :return: RG node ID string if all *system_ids* form exactly one RG,
+             otherwise ``None``.
+    """
+    if not system_ids or len(system_ids) < 2:
+        return None
+
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+        find_redundancy_groups,
+    )
+
+    rg_map = find_redundancy_groups(client_factory, blueprint_id)
+    if not rg_map:
+        return None
+
+    target = set(system_ids)
+    for rg_id, info in rg_map.items():
+        if set(info.get("members", [])) == target:
+            return rg_id
+
+    return None
+
+
 # ──────────────────────────────────────────────────────────────────
 #  bound_to keyword expansion  (virtual_network / VN binding)
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -694,13 +694,13 @@ def resolve_bound_to_keyword(client_factory, blueprint_id, keyword):
 
     # Strategy 2 — QE graph traversal.
     # Other Apstra versions store tags as separate 'tag' graph nodes
-    # connected to system nodes via outgoing edges.  Use .out() without
-    # an edge-type argument (same pattern as find_redundancy_groups) so
-    # the traversal is not sensitive to the internal edge-type name.
+    # with outgoing edges pointing TO system nodes (tag → system).
+    # Use .out() without an edge-type argument so the traversal is not
+    # sensitive to the internal edge-type name.
     results = _run_qe(
         client_factory,
         blueprint_id,
-        "node('system', name='sys').out().node('tag', name='t')",
+        "node('tag', name='t').out().node('system', name='sys')",
     )
     if results:
         matching = list(

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -577,6 +577,83 @@ def resolve_esi_member_ids(client_factory, blueprint_id, node_ref):
 
 
 # ──────────────────────────────────────────────────────────────────
+#  bound_to keyword expansion  (virtual_network / VN binding)
+# ──────────────────────────────────────────────────────────────────
+
+# Map lower-case keyword → Apstra role list (None = no filter → all systems)
+_BOUND_TO_ROLE_KEYWORDS = {
+    "all": None,
+    "spine": ["spine"],
+    "spines": ["spine"],
+    "leaf": ["leaf"],
+    "leafs": ["leaf"],
+    "leaves": ["leaf"],
+    "access": ["access"],
+    "accesses": ["access"],
+    "superspine": ["superspine"],
+    "superspines": ["superspine"],
+}
+
+
+def resolve_bound_to_keyword(client_factory, blueprint_id, keyword):
+    """Expand a ``bound_to`` ``system_id`` keyword to a list of system node IDs.
+
+    Supports the following built-in keywords (case-insensitive):
+
+    * ``"all"`` — every system node in the blueprint.
+    * ``"spine"`` / ``"spines"`` — systems with role ``spine``.
+    * ``"leaf"`` / ``"leafs"`` / ``"leaves"`` — systems with role ``leaf``.
+    * ``"access"`` / ``"accesses"`` — systems with role ``access``.
+    * ``"superspine"`` / ``"superspines"`` — systems with role ``superspine``.
+    * ``<tag_label>`` — all systems that carry a blueprint tag whose label
+      exactly matches *keyword* (case-sensitive).
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param blueprint_id: The blueprint UUID.
+    :param keyword: The keyword to expand.
+    :return: A (possibly empty) list of system graph-node ID strings when
+        *keyword* is a recognised built-in keyword **or** an existing tag
+        label.  Returns ``None`` when *keyword* matches neither, so the
+        caller can fall back to :func:`resolve_system_node_id`.
+    """
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+        find_nodes_by_role,
+    )
+
+    kw_lower = keyword.lower()
+
+    # ── Built-in role keywords ────────────────────────────────────
+    if kw_lower in _BOUND_TO_ROLE_KEYWORDS:
+        roles = _BOUND_TO_ROLE_KEYWORDS[kw_lower]
+        nodes = find_nodes_by_role(client_factory, blueprint_id, roles)
+        return [n["id"] for n in nodes.values()]
+
+    # ── Tag-based expansion ───────────────────────────────────────
+    # Query all (system, tag) pairs via the blueprint graph; filter by tag
+    # label in Python.  *keyword* is intentionally NOT interpolated into the
+    # QE string to avoid graph-query injection — matching is done here.
+    results = _run_qe(
+        client_factory,
+        blueprint_id,
+        "node('system', name='sys').out('tag').node('tag', name='t')",
+    )
+    if results:
+        matching = list(
+            {
+                r["sys"]["id"]
+                for r in results
+                if (r.get("t") or {}).get("label") == keyword
+            }
+        )
+        if matching:
+            return matching
+
+    # Not a built-in keyword and no matching tag — caller should treat as a
+    # regular system label / UUID.
+    return None
+
+
+# ──────────────────────────────────────────────────────────────────
 #  Interface / application-point resolution
 # ──────────────────────────────────────────────────────────────────
 

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -580,9 +580,11 @@ def resolve_esi_member_ids(client_factory, blueprint_id, node_ref):
 #  bound_to keyword expansion  (virtual_network / VN binding)
 # ──────────────────────────────────────────────────────────────────
 
-# Map lower-case keyword → Apstra role list (None = no filter → all systems)
+# Map lower-case keyword → Apstra role list.
+# "all" expands to roles valid as bound_to targets (leaf + access).
+# Spines and superspines are not valid bound_to endpoints for virtual networks.
 _BOUND_TO_ROLE_KEYWORDS = {
-    "all": None,
+    "all": ["leaf", "access"],
     "spine": ["spine"],
     "spines": ["spine"],
     "leaf": ["leaf"],
@@ -629,13 +631,31 @@ def resolve_bound_to_keyword(client_factory, blueprint_id, keyword):
         return [n["id"] for n in nodes.values()]
 
     # ── Tag-based expansion ───────────────────────────────────────
-    # Query all (system, tag) pairs via the blueprint graph; filter by tag
-    # label in Python.  *keyword* is intentionally NOT interpolated into the
-    # QE string to avoid graph-query injection — matching is done here.
+    # *keyword* is never interpolated into any QE string to prevent
+    # graph-query injection; all tag-label matching is done in Python.
+    #
+    # Strategy 1 — system node 'tags' property.
+    # Some Apstra versions store applied tag labels as a list property
+    # directly on the system graph node.
+    sys_results = _run_qe(client_factory, blueprint_id, "node('system', name='sys')")
+    if sys_results:
+        matching = [
+            r["sys"]["id"]
+            for r in sys_results
+            if keyword in ((r.get("sys") or {}).get("tags") or [])
+        ]
+        if matching:
+            return matching
+
+    # Strategy 2 — QE graph traversal.
+    # Other Apstra versions store tags as separate 'tag' graph nodes
+    # connected to system nodes via outgoing edges.  Use .out() without
+    # an edge-type argument (same pattern as find_redundancy_groups) so
+    # the traversal is not sensitive to the internal edge-type name.
     results = _run_qe(
         client_factory,
         blueprint_id,
-        "node('system', name='sys').out('tag').node('tag', name='t')",
+        "node('system', name='sys').out().node('tag', name='t')",
     )
     if results:
         matching = list(

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -576,6 +576,51 @@ def resolve_esi_member_ids(client_factory, blueprint_id, node_ref):
     return None
 
 
+def resolve_rg_node_id(client_factory, blueprint_id, node_ref):
+    """Return the redundancy-group graph-node ID if *node_ref* is an RG
+    label or ID, otherwise return ``None``.
+
+    Apstra stores bound_to entries using the **RG node ID** (not the
+    individual member system IDs) whenever the bound systems form an
+    ESI or MLAG redundancy group.  Using the RG node ID in POST/PATCH
+    requests produces a GET response that is identical to the desired
+    state, which is required for idempotency.
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param blueprint_id: The blueprint UUID.
+    :param node_ref: A candidate RG label or graph-node ID string.
+    :return: The RG graph-node ID string if *node_ref* matches an RG,
+             otherwise ``None``.
+    """
+    if not node_ref:
+        return None
+
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+        find_redundancy_groups,
+    )
+
+    rg_map = find_redundancy_groups(client_factory, blueprint_id)
+    if not rg_map:
+        return None
+
+    # Exact ID match
+    if node_ref in rg_map:
+        return node_ref
+
+    # Exact label match
+    for rg_id, info in rg_map.items():
+        if info["label"] == node_ref:
+            return rg_id
+
+    # Case-insensitive label fallback
+    ref_lower = node_ref.lower()
+    for rg_id, info in rg_map.items():
+        if info["label"].lower() == ref_lower:
+            return rg_id
+
+    return None
+
+
 # ──────────────────────────────────────────────────────────────────
 #  bound_to keyword expansion  (virtual_network / VN binding)
 # ──────────────────────────────────────────────────────────────────

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -208,11 +208,15 @@ options:
     required: false
   node_id:
     description:
-      - The blueprint node ID to patch (single-node mode).
+      - The blueprint node(s) to patch in C(state=node_updated).
+      - Accepts a single value or a list of values.
+      - Each value may be a node UUID, a graph-node short ID, or a
+        device label (e.g. C(leaf1)).  Labels are resolved to their
+        graph-node UUID automatically.
       - Mutually exclusive with C(assignment).
       - Only used when C(state=node_updated).
       - Alias C(rack_id) can be used for rack operations.
-    type: str
+    type: raw
     required: false
     aliases: [rack_id]
   system_id:
@@ -386,7 +390,27 @@ EXAMPLES = """
     system_id: "SERIAL12345"
     state: node_updated
 
-# Set deploy mode on a node
+# Set deploy mode on a node by label (no UUID lookup needed)
+- name: Set leaf1 to drain mode by label
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    node_id: "leaf1"
+    deploy_mode: drain
+    state: node_updated
+
+# Set deploy mode on multiple nodes by label (list form)
+- name: Set leaf1 and leaf2 to drain mode
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    node_id:
+      - "leaf1"
+      - "leaf2"
+    deploy_mode: drain
+    state: node_updated
+
+# Set deploy mode on a node (legacy UUID form still works)
 - name: Set leaf1 to deploy mode
   juniper.apstra.blueprint:
     id:
@@ -544,6 +568,7 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolut
     resolve_template_id as _resolve_template_id,
     resolve_graph_node_id,
     resolve_rack_node_id,
+    resolve_system_node_id,
 )
 
 
@@ -803,12 +828,20 @@ def _handle_node_updated(module, client_factory, blueprint_id):
             msg="Either node_id, current_label, or assignment is required when state=node_updated"
         )
 
-    # Read current node state
-    current = get_node(client_factory, blueprint_id, node_id)
-    if current is None:
-        module.fail_json(
-            msg=f"Node '{node_id}' not found in blueprint '{blueprint_id}'"
-        )
+    # Normalise: node_id may be a str or a list of str
+    if isinstance(node_id, str):
+        node_ids = [node_id]
+    else:
+        node_ids = list(node_id)
+
+    # Resolve each entry: label → graph-node UUID via system node resolution
+    resolved_ids = []
+    for nid in node_ids:
+        try:
+            resolved = resolve_system_node_id(client_factory, blueprint_id, nid)
+        except ValueError as exc:
+            module.fail_json(msg=str(exc))
+        resolved_ids.append((nid, resolved))
 
     # Build desired fields from params
     desired = {}
@@ -830,25 +863,54 @@ def _handle_node_updated(module, client_factory, blueprint_id):
     if not desired:
         return dict(
             changed=False,
-            node=current,
             msg="no node fields to update",
         )
 
-    # Only patch what actually changed
-    changes = node_needs_update(current, desired)
-    if not changes:
-        return dict(
-            changed=False,
-            node=current,
-            msg="node already up to date",
-        )
+    # Apply to each resolved node
+    nodes_updated = []
+    nodes_unchanged = []
+    for orig_ref, resolved_id in resolved_ids:
+        current = get_node(client_factory, blueprint_id, resolved_id)
+        if current is None:
+            module.fail_json(
+                msg=f"Node '{orig_ref}' (resolved: {resolved_id}) not found in blueprint '{blueprint_id}'"
+            )
 
-    patch_node(client_factory, blueprint_id, node_id, changes)
-    final = {**current, **changes}
+        changes = node_needs_update(current, desired)
+        if not changes:
+            nodes_unchanged.append(resolved_id)
+            continue
+
+        patch_node(client_factory, blueprint_id, resolved_id, changes)
+        nodes_updated.append({**current, **changes, "node_id": resolved_id})
+
+    # Return single-node result format when only one node was targeted
+    if len(resolved_ids) == 1:
+        orig_ref, resolved_id = resolved_ids[0]
+        if nodes_updated:
+            node_state = nodes_updated[0]
+            return dict(
+                changed=True,
+                node=node_state,
+                node_id=resolved_id,
+                msg=f"node updated: {', '.join(k for k in desired if k in node_state)}",
+            )
+        else:
+            return dict(
+                changed=False,
+                node=get_node(client_factory, blueprint_id, resolved_id),
+                node_id=resolved_id,
+                msg="node already up to date",
+            )
+
+    # Multi-node result format
+    n = len(nodes_updated)
+    u = len(nodes_unchanged)
     return dict(
-        changed=True,
-        node=final,
-        msg=f"node updated: {', '.join(changes.keys())}",
+        changed=bool(nodes_updated),
+        nodes_updated=nodes_updated,
+        nodes_unchanged=nodes_unchanged,
+        msg=f"{n} node(s) updated, {u} already up to date",
     )
 
 
@@ -903,7 +965,7 @@ def main():
         if_type=dict(type="str", required=False, default="ethernet"),
         # Node params (state=node_updated)
         assignment=dict(type="dict", required=False),
-        node_id=dict(type="str", required=False, aliases=["rack_id"]),
+        node_id=dict(type="raw", required=False, aliases=["rack_id"]),
         system_id=dict(type="str", required=False),
         deploy_mode=dict(
             type="str",

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_infra_manager.py
@@ -634,15 +634,22 @@ def _handle_global_vim(module, client_factory, id, body, state, result):
             current_object = items[0] if items else None
         else:
             current_object = raw
-    elif body and body.get("display_name"):
-        # Search by display_name in the list
+    elif body and (body.get("display_name") or body.get("management_ip")):
+        # Search by display_name or management_ip in the list
         all_vims = client_factory.object_request(object_type, "get", {})
         # Handle both bare list and {"items": [...]} wrapper
         if isinstance(all_vims, dict) and "items" in all_vims:
             all_vims = all_vims.get("items", [])
         if isinstance(all_vims, list):
             for vim in all_vims:
-                if vim.get("display_name") == body["display_name"]:
+                match = (
+                    body.get("display_name")
+                    and vim.get("display_name") == body["display_name"]
+                ) or (
+                    body.get("management_ip")
+                    and vim.get("management_ip") == body["management_ip"]
+                )
+                if match:
                     current_object = vim
                     if id is None:
                         id = {}

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -111,6 +111,23 @@ EXAMPLES = """
           vlan_id: 100
     state: present
 
+- name: Create virtual network with static IPv4
+  juniper.apstra.virtual_network:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "Test-VN-static-IPv4"
+      vn_type: "vxlan"
+      security_zone_id: "my-routing-zone"
+      vlan_id: 23
+      ipv4_enabled: true
+      ipv4_subnet: 192.0.2.0/24
+      virtual_gateway_ipv4_enabled: true
+      virtual_gateway_ipv4: 192.0.2.254/24
+      bound_to:
+        - system_id: "spine1"
+    state: present
+
 # Global vlan_id — applies to every bound_to entry that has no per-device override
 - name: Create virtual network with global VLAN ID
   juniper.apstra.virtual_network:

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -293,6 +293,7 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolut
     resolve_system_node_id,
     resolve_security_zone_id,
     resolve_esi_member_ids,
+    resolve_rg_node_id,
     resolve_bound_to_keyword,
 )
 
@@ -377,31 +378,46 @@ def main():
 
                     if "system_id" in entry and bp_id:
                         sys_ref = entry["system_id"]
-                        # Step 0: keyword expansion (all, leafs, spines, <tag>)
-                        keyword_ids = resolve_bound_to_keyword(
-                            client_factory, bp_id, sys_ref
-                        )
-                        if keyword_ids is not None:
-                            for node_id in keyword_ids:
-                                kw_entry = dict(entry)
-                                kw_entry["system_id"] = node_id
-                                expanded.append(kw_entry)
+                        # Step 0: RG label/ID → use RG node ID directly.
+                        # Apstra stores bound_to entries as RG node IDs (not
+                        # individual member IDs) when the systems form an ESI
+                        # or MLAG redundancy group.  By resolving the RG label
+                        # to its node ID *before* tag expansion we ensure that
+                        # the desired state matches what GET returns, which is
+                        # required for idempotency.  An RG label that also
+                        # happens to be a blueprint tag (a common naming
+                        # convention) would otherwise be expanded into the
+                        # individual member system IDs, causing a mismatch.
+                        rg_id = resolve_rg_node_id(client_factory, bp_id, sys_ref)
+                        if rg_id is not None:
+                            entry["system_id"] = rg_id
+                            expanded.append(entry)
                         else:
-                            # Step 1: ESI/MLAG redundancy group expansion
-                            member_ids = resolve_esi_member_ids(
+                            # Step 1: keyword expansion (all, leafs, spines, <tag>)
+                            keyword_ids = resolve_bound_to_keyword(
                                 client_factory, bp_id, sys_ref
                             )
-                            if member_ids is not None:
-                                for mbr_id in member_ids:
-                                    mbr_entry = dict(entry)
-                                    mbr_entry["system_id"] = mbr_id
-                                    expanded.append(mbr_entry)
+                            if keyword_ids is not None:
+                                for node_id in keyword_ids:
+                                    kw_entry = dict(entry)
+                                    kw_entry["system_id"] = node_id
+                                    expanded.append(kw_entry)
                             else:
-                                # Step 2: regular system node — resolve label
-                                entry["system_id"] = resolve_system_node_id(
+                                # Step 2: ESI/MLAG redundancy group expansion
+                                member_ids = resolve_esi_member_ids(
                                     client_factory, bp_id, sys_ref
                                 )
-                                expanded.append(entry)
+                                if member_ids is not None:
+                                    for mbr_id in member_ids:
+                                        mbr_entry = dict(entry)
+                                        mbr_entry["system_id"] = mbr_id
+                                        expanded.append(mbr_entry)
+                                else:
+                                    # Step 3: regular system node — resolve label
+                                    entry["system_id"] = resolve_system_node_id(
+                                        client_factory, bp_id, sys_ref
+                                    )
+                                    expanded.append(entry)
                     else:
                         expanded.append(entry)
 

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -295,6 +295,7 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolut
     resolve_esi_member_ids,
     resolve_rg_node_id,
     resolve_bound_to_keyword,
+    collapse_to_rg_if_applicable,
 )
 
 
@@ -398,10 +399,20 @@ def main():
                                 client_factory, bp_id, sys_ref
                             )
                             if keyword_ids is not None:
-                                for node_id in keyword_ids:
-                                    kw_entry = dict(entry)
-                                    kw_entry["system_id"] = node_id
-                                    expanded.append(kw_entry)
+                                # If the expanded IDs are the complete membership
+                                # of one RG, Apstra will store the RG node ID in
+                                # GET — use it directly to stay idempotent.
+                                rg_node = collapse_to_rg_if_applicable(
+                                    client_factory, bp_id, keyword_ids
+                                )
+                                if rg_node is not None:
+                                    entry["system_id"] = rg_node
+                                    expanded.append(entry)
+                                else:
+                                    for node_id in keyword_ids:
+                                        kw_entry = dict(entry)
+                                        kw_entry["system_id"] = node_id
+                                        expanded.append(kw_entry)
                             else:
                                 # Step 2: ESI/MLAG redundancy group expansion
                                 member_ids = resolve_esi_member_ids(

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -128,20 +128,20 @@ EXAMPLES = """
         - system_id: "spine1"
     state: present
 
-# Global vlan_id — applies to every bound_to entry that has no per-device override
-- name: Create virtual network with global VLAN ID
+# vlan_id at the VN level applies globally; per-device overrides go inside bound_to entries
+- name: Create virtual network with VLAN ID
   juniper.apstra.virtual_network:
     id:
       blueprint: "my-blueprint"
     body:
       label: "prod-vn"
       vn_type: "vxlan"
-      vlan_id: 100
+      vlan_id: 100          # VN-level VLAN; Apstra stores and returns it here
       bound_to:
         - system_id: "leaf1"
         - system_id: "leaf2"
         - system_id: "leaf3"
-          vlan_id: 200    # per-device override wins
+          vlan_id: 200    # per-device override — overrides the VN-level vlan_id on leaf3 only
     state: present
 
 # ESI pair expansion — specify the redundancy-group name; the module expands
@@ -339,21 +339,18 @@ def main():
             # Ensure vn_id is a string
             if "vn_id" in body and body["vn_id"] is not None:
                 body["vn_id"] = str(body["vn_id"])
-            # Feature: consume top-level vlan_id as global default for bound_to
-            # entries.  The value is stripped from body before the API call so it
-            # is never forwarded to Apstra as a VN-level field.
-            # When bound_to is absent, vlan_id is kept in body and passed through
-            # to the API as a VN-level field (existing behaviour).
-            global_vlan_id = None
-            if "vlan_id" in body and "bound_to" in body:
-                global_vlan_id = body.pop("vlan_id")
-                if global_vlan_id is not None:
-                    global_vlan_id = int(global_vlan_id)
-            elif "vlan_id" in body and body["vlan_id"] is not None:
+            # Keep vlan_id at the VN level — Apstra stores it there and
+            # returns it in GET responses.  Injecting it into per-device
+            # bound_to entries caused permanent idempotency failures because
+            # Apstra returns vlan_id=null in each bound_to entry while the
+            # desired state had the numeric value.
+            # Per-device vlan_id overrides are still supported by specifying
+            # vlan_id directly inside a bound_to entry in the playbook.
+            if "vlan_id" in body and body["vlan_id"] is not None:
                 body["vlan_id"] = int(body["vlan_id"])
 
-            # Process bound_to: normalise, apply global vlan_id default,
-            # expand ESI redundancy groups, and resolve system names to IDs.
+            # Process bound_to: normalise, expand keywords/ESI groups,
+            # and resolve system names to IDs.
             if "bound_to" in body and isinstance(body["bound_to"], list):
                 bp_id = id.get("blueprint")
                 expanded = []
@@ -364,13 +361,10 @@ def main():
                     else:
                         entry = dict(entry)  # shallow copy — avoid mutating params
 
-                    # Coerce per-entry vlan_id to int
+                    # Coerce per-entry vlan_id to int (explicit per-device
+                    # override; VN-level vlan_id is handled above)
                     if "vlan_id" in entry and entry["vlan_id"] is not None:
                         entry["vlan_id"] = int(entry["vlan_id"])
-
-                    # Apply global vlan_id when the entry carries no override
-                    if global_vlan_id is not None and "vlan_id" not in entry:
-                        entry["vlan_id"] = global_vlan_id
 
                     if "system_id" in entry and bp_id:
                         sys_ref = entry["system_id"]

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -158,6 +158,55 @@ EXAMPLES = """
         - system_id: "apstra_esi_001_leaf_pair1"   # ESI redundancy group
     state: present
 
+# Keyword expansion — bind a VN to all nodes of a role or with a tag in one entry
+- name: Bind virtual network to all leaf switches
+  juniper.apstra.virtual_network:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "VLAN100"
+      vn_type: "vxlan"
+      vlan_id: 100
+      bound_to:
+        - system_id: leafs    # expands to all role='leaf' systems
+    state: present
+
+- name: Bind virtual network to all spines
+  juniper.apstra.virtual_network:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "VLAN200"
+      vn_type: "vxlan"
+      vlan_id: 200
+      bound_to:
+        - system_id: spines   # expands to all role='spine' systems
+    state: present
+
+- name: Bind virtual network to every system (all)
+  juniper.apstra.virtual_network:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "VLAN300"
+      vn_type: "vxlan"
+      vlan_id: 300
+      bound_to:
+        - system_id: all      # expands to every system node
+    state: present
+
+- name: Bind virtual network to tagged compute nodes
+  juniper.apstra.virtual_network:
+    id:
+      blueprint: "my-blueprint"
+    body:
+      label: "VLANXX"
+      vn_type: "vxlan"
+      vlan_id: 400
+      bound_to:
+        - system_id: compute  # expands to all systems tagged 'compute'
+    state: present
+
 # create_policy_tagged — use when you want ONLY a tagged CT and no auto-untagged CT.
 # Without this, Apstra normally expects an untagged CT; by default the module sets
 # create_policy_untagged=True automatically for vxlan VNs.  Setting
@@ -243,6 +292,7 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolut
     resolve_system_node_id,
     resolve_security_zone_id,
     resolve_esi_member_ids,
+    resolve_bound_to_keyword,
 )
 
 
@@ -324,22 +374,31 @@ def main():
 
                     if "system_id" in entry and bp_id:
                         sys_ref = entry["system_id"]
-                        # Check if this is an ESI/MLAG redundancy group:
-                        # if so, expand into one entry per member device.
-                        member_ids = resolve_esi_member_ids(
+                        # Step 0: keyword expansion (all, leafs, spines, <tag>)
+                        keyword_ids = resolve_bound_to_keyword(
                             client_factory, bp_id, sys_ref
                         )
-                        if member_ids is not None:
-                            for mbr_id in member_ids:
-                                mbr_entry = dict(entry)
-                                mbr_entry["system_id"] = mbr_id
-                                expanded.append(mbr_entry)
+                        if keyword_ids is not None:
+                            for node_id in keyword_ids:
+                                kw_entry = dict(entry)
+                                kw_entry["system_id"] = node_id
+                                expanded.append(kw_entry)
                         else:
-                            # Regular system node — resolve label to graph ID
-                            entry["system_id"] = resolve_system_node_id(
+                            # Step 1: ESI/MLAG redundancy group expansion
+                            member_ids = resolve_esi_member_ids(
                                 client_factory, bp_id, sys_ref
                             )
-                            expanded.append(entry)
+                            if member_ids is not None:
+                                for mbr_id in member_ids:
+                                    mbr_entry = dict(entry)
+                                    mbr_entry["system_id"] = mbr_id
+                                    expanded.append(mbr_entry)
+                            else:
+                                # Step 2: regular system node — resolve label
+                                entry["system_id"] = resolve_system_node_id(
+                                    client_factory, bp_id, sys_ref
+                                )
+                                expanded.append(entry)
                     else:
                         expanded.append(entry)
 

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -465,25 +465,60 @@ def main():
             if current_object:
                 result["id"] = id
                 if body:
-                    # Apstra stores vlan_id at the VN level and returns null for
-                    # each bound_to entry.  Strip per-entry vlan_id from the
-                    # desired bound_to before comparison so injected global
-                    # defaults and explicit per-device overrides do not cause
-                    # permanent changed=True.  The full bound_to (with per-entry
-                    # vlan_id) is kept in body and used for the actual patch call.
-                    comparison_body = body
-                    if "bound_to" in body and any(
-                        "vlan_id" in e for e in body["bound_to"]
-                    ):
-                        comparison_body = dict(body)
-                        comparison_body["bound_to"] = [
-                            {k: v for k, v in e.items() if k != "vlan_id"}
+                    # Normalise current_object's bound_to entries so the
+                    # comparison uses real-time data without needing to strip
+                    # vlan_id from the desired state.
+                    #
+                    # Apstra stores vlan_id on each vn_instance node and
+                    # returns it in GET responses (compact_dict keeps non-null
+                    # values).  Some deployments normalise it to the VN level
+                    # and return null per bound_to entry.  To handle both:
+                    #
+                    # - Fill current entries that are missing vlan_id with
+                    #   global_vlan_id, BUT ONLY when the matching desired
+                    #   entry also carries the global default (not an explicit
+                    #   per-device override).  This makes the comparison
+                    #   apples-to-apples for the common "one VLAN for all"
+                    #   case without masking override changes.
+                    #
+                    # - Entries with an EXPLICIT per-device override
+                    #   (desired vlan_id != global_vlan_id) are left as
+                    #   returned by GET.  If Apstra stored the value it will
+                    #   be present and the comparison is exact; if it returned
+                    #   null the comparison detects the pending change.
+                    #
+                    # comparison_body is always body (unmodified desired).
+                    comparison_current = current_object
+                    if global_vlan_id is not None and "bound_to" in body:
+                        # System IDs that carry an explicit per-device override
+                        explicit_override_ids = {
+                            e["system_id"]
                             for e in body["bound_to"]
-                        ]
+                            if "system_id" in e
+                            and e.get("vlan_id") not in (None, global_vlan_id)
+                        }
+                        current_bound_to = current_object.get("bound_to", [])
+                        if any(
+                            "vlan_id" not in e or e.get("vlan_id") is None
+                            for e in current_bound_to
+                        ):
+                            normalized = []
+                            for entry in current_bound_to:
+                                if (
+                                    "vlan_id" not in entry
+                                    or entry.get("vlan_id") is None
+                                ) and entry.get(
+                                    "system_id"
+                                ) not in explicit_override_ids:
+                                    entry = dict(entry)
+                                    entry["vlan_id"] = global_vlan_id
+                                normalized.append(entry)
+                            comparison_current = dict(current_object)
+                            comparison_current["bound_to"] = normalized
                     # Update the object
                     changes = {}
                     if client_factory.compare_and_update(
-                        current_object, comparison_body, changes
+                        comparison_current, body, changes
                     ):
                         # Restore full bound_to (with per-entry vlan_id) if it
                         # changed, so the patch carries the correct per-device values

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -465,60 +465,42 @@ def main():
             if current_object:
                 result["id"] = id
                 if body:
-                    # Normalise current_object's bound_to entries so the
-                    # comparison uses real-time data without needing to strip
-                    # vlan_id from the desired state.
+                    # Strip vlan_id from bound_to on BOTH sides before
+                    # comparison.
                     #
-                    # Apstra stores vlan_id on each vn_instance node and
-                    # returns it in GET responses (compact_dict keeps non-null
-                    # values).  Some deployments normalise it to the VN level
-                    # and return null per bound_to entry.  To handle both:
+                    # Live testing confirmed that Apstra auto-assigns per-
+                    # vn_instance VLANs independently of the user-supplied
+                    # value (EVPN blueprints assign their own VLAN; non-EVPN
+                    # may also normalise the value).  Sending a specific
+                    # vlan_id per bound_to entry is still useful for
+                    # deployments that honour it (the value is kept in body
+                    # and sent in create/patch API calls), but comparing it
+                    # against the GET response always produces a spurious
+                    # mismatch because Apstra stores a different value.
                     #
-                    # - Fill current entries that are missing vlan_id with
-                    #   global_vlan_id, BUT ONLY when the matching desired
-                    #   entry also carries the global default (not an explicit
-                    #   per-device override).  This makes the comparison
-                    #   apples-to-apples for the common "one VLAN for all"
-                    #   case without masking override changes.
-                    #
-                    # - Entries with an EXPLICIT per-device override
-                    #   (desired vlan_id != global_vlan_id) are left as
-                    #   returned by GET.  If Apstra stored the value it will
-                    #   be present and the comparison is exact; if it returned
-                    #   null the comparison detects the pending change.
-                    #
-                    # comparison_body is always body (unmodified desired).
+                    # VN-level vlan_id (body["vlan_id"]) is NOT stripped and
+                    # is still compared normally by compare_and_update.
+                    def _strip_vlan_id(entries):
+                        return [
+                            {k: v for k, v in e.items() if k != "vlan_id"}
+                            for e in entries
+                        ]
+
+                    comparison_body = body
                     comparison_current = current_object
-                    if global_vlan_id is not None and "bound_to" in body:
-                        # System IDs that carry an explicit per-device override
-                        explicit_override_ids = {
-                            e["system_id"]
-                            for e in body["bound_to"]
-                            if "system_id" in e
-                            and e.get("vlan_id") not in (None, global_vlan_id)
-                        }
-                        current_bound_to = current_object.get("bound_to", [])
-                        if any(
-                            "vlan_id" not in e or e.get("vlan_id") is None
-                            for e in current_bound_to
-                        ):
-                            normalized = []
-                            for entry in current_bound_to:
-                                if (
-                                    "vlan_id" not in entry
-                                    or entry.get("vlan_id") is None
-                                ) and entry.get(
-                                    "system_id"
-                                ) not in explicit_override_ids:
-                                    entry = dict(entry)
-                                    entry["vlan_id"] = global_vlan_id
-                                normalized.append(entry)
-                            comparison_current = dict(current_object)
-                            comparison_current["bound_to"] = normalized
+                    desired_bt = body.get("bound_to", [])
+                    current_bt = (current_object or {}).get("bound_to", [])
+                    if any("vlan_id" in e for e in desired_bt) or any(
+                        "vlan_id" in e for e in current_bt
+                    ):
+                        comparison_body = dict(body)
+                        comparison_body["bound_to"] = _strip_vlan_id(desired_bt)
+                        comparison_current = dict(current_object)
+                        comparison_current["bound_to"] = _strip_vlan_id(current_bt)
                     # Update the object
                     changes = {}
                     if client_factory.compare_and_update(
-                        comparison_current, body, changes
+                        comparison_current, comparison_body, changes
                     ):
                         # Restore full bound_to (with per-entry vlan_id) if it
                         # changed, so the patch carries the correct per-device values

--- a/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/virtual_network.py
@@ -128,20 +128,21 @@ EXAMPLES = """
         - system_id: "spine1"
     state: present
 
-# vlan_id at the VN level applies globally; per-device overrides go inside bound_to entries
-- name: Create virtual network with VLAN ID
+# Global vlan_id — injected as a default into every bound_to entry that has
+# no per-device override, then also kept at the VN level for idempotency.
+- name: Create virtual network with global VLAN ID
   juniper.apstra.virtual_network:
     id:
       blueprint: "my-blueprint"
     body:
       label: "prod-vn"
       vn_type: "vxlan"
-      vlan_id: 100          # VN-level VLAN; Apstra stores and returns it here
+      vlan_id: 100
       bound_to:
         - system_id: "leaf1"
         - system_id: "leaf2"
         - system_id: "leaf3"
-          vlan_id: 200    # per-device override — overrides the VN-level vlan_id on leaf3 only
+          vlan_id: 200    # per-device override wins; leaf1/leaf2 get vlan_id 100
     state: present
 
 # ESI pair expansion — specify the redundancy-group name; the module expands
@@ -339,15 +340,19 @@ def main():
             # Ensure vn_id is a string
             if "vn_id" in body and body["vn_id"] is not None:
                 body["vn_id"] = str(body["vn_id"])
-            # Keep vlan_id at the VN level — Apstra stores it there and
-            # returns it in GET responses.  Injecting it into per-device
-            # bound_to entries caused permanent idempotency failures because
-            # Apstra returns vlan_id=null in each bound_to entry while the
-            # desired state had the numeric value.
-            # Per-device vlan_id overrides are still supported by specifying
-            # vlan_id directly inside a bound_to entry in the playbook.
+            # Keep vlan_id at the VN level (Apstra stores/returns it here).
+            # Also propagate it as a global default into bound_to entries
+            # that carry no per-device override — a convenience so the user
+            # does not have to repeat the same vlan_id in every entry.
+            # Note: Apstra normalises vlan_id to the VN level and returns
+            # null per bound_to entry in GET responses.  Per-entry vlan_id
+            # values are stripped from the desired state before the
+            # idempotency comparison (see compare_and_update call below).
+            global_vlan_id = None
             if "vlan_id" in body and body["vlan_id"] is not None:
                 body["vlan_id"] = int(body["vlan_id"])
+                if "bound_to" in body:
+                    global_vlan_id = body["vlan_id"]
 
             # Process bound_to: normalise, expand keywords/ESI groups,
             # and resolve system names to IDs.
@@ -365,6 +370,10 @@ def main():
                     # override; VN-level vlan_id is handled above)
                     if "vlan_id" in entry and entry["vlan_id"] is not None:
                         entry["vlan_id"] = int(entry["vlan_id"])
+
+                    # Apply global vlan_id when the entry has no per-device override
+                    if global_vlan_id is not None and "vlan_id" not in entry:
+                        entry["vlan_id"] = global_vlan_id
 
                     if "system_id" in entry and bp_id:
                         sys_ref = entry["system_id"]
@@ -456,9 +465,30 @@ def main():
             if current_object:
                 result["id"] = id
                 if body:
+                    # Apstra stores vlan_id at the VN level and returns null for
+                    # each bound_to entry.  Strip per-entry vlan_id from the
+                    # desired bound_to before comparison so injected global
+                    # defaults and explicit per-device overrides do not cause
+                    # permanent changed=True.  The full bound_to (with per-entry
+                    # vlan_id) is kept in body and used for the actual patch call.
+                    comparison_body = body
+                    if "bound_to" in body and any(
+                        "vlan_id" in e for e in body["bound_to"]
+                    ):
+                        comparison_body = dict(body)
+                        comparison_body["bound_to"] = [
+                            {k: v for k, v in e.items() if k != "vlan_id"}
+                            for e in body["bound_to"]
+                        ]
                     # Update the object
                     changes = {}
-                    if client_factory.compare_and_update(current_object, body, changes):
+                    if client_factory.compare_and_update(
+                        current_object, comparison_body, changes
+                    ):
+                        # Restore full bound_to (with per-entry vlan_id) if it
+                        # changed, so the patch carries the correct per-device values
+                        if "bound_to" in changes:
+                            changes["bound_to"] = body["bound_to"]
                         updated_object = client_factory.object_request(
                             object_type, "patch", id, changes
                         )


### PR DESCRIPTION
feat(blueprint): allow node_id to accept device label and list of nodes
state=node_updated node_id parameter now supports:

1. Device label / name (e.g. 'leaf1') in addition to raw UUIDs.
   Labels are resolved to graph-node IDs via resolve_system_node_id(),
   which performs exact-ID → exact-label → case-insensitive-label lookup.

2. List of node references (str or label), allowing a single task to
   update deploy_mode (or other node properties) on multiple devices:

     node_id:
       - leaf1
       - leaf2
     deploy_mode: drain

   Multi-node result includes nodes_updated / nodes_unchanged lists.
   Single-node result format is unchanged for backward compatibility.
   
feat(virtual_network): keyword expansion for bound_to system_id
bound_to entries now accept a keyword in place of a specific system
label, allowing one task to bind a virtual network to a dynamic set
of devices:

  bound_to:
    - system_id: leafs    # all role='leaf' systems
    - system_id: spines   # all role='spine' systems
    - system_id: all      # every system node in the blueprint
    - system_id: compute  # all systems tagged 'compute'

Built-in role keywords (case-insensitive):
  all, spine/spines, leaf/leafs/leaves,
  access/accesses, superspine/superspines

Tag-based expansion: any other value is looked up as a blueprint tag
label (case-sensitive).  Systems carrying that tag are expanded into
individual bound_to entries.  The tag label is never interpolated into
the QE query string; matching is performed in Python to prevent
graph-query injection.

When a keyword produces multiple systems, global vlan_id and any per-
entry overrides are carried through to every expanded entry as-is.

If a value matches neither a built-in keyword nor an existing tag it
falls through to the existing ESI-group and label/UUID resolution path,
so backward compatibility is fully preserved.