### PR TITLE
fix(blueprint): correct node resolution in state=node_updated for non-system nodes

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -796,6 +796,7 @@ def _handle_node_updated(module, client_factory, blueprint_id):
     # ── Resolve current_label → node_id ────────────────────────────────────
     current_label = params.get("current_label")
     node_type = params.get("node_type")
+    node_id_already_resolved = False
     if current_label and not node_id:
         if node_type == "rack":
             try:
@@ -821,6 +822,7 @@ def _handle_node_updated(module, client_factory, blueprint_id):
                     msg=f"No node{filter_msg} with label '{current_label}' found in blueprint '{blueprint_id}'"
                 )
             node_id = matched_id
+        node_id_already_resolved = True
 
     # ── Single-node mode (node_id) ────────────────────────────────────────
     if not node_id:
@@ -834,14 +836,21 @@ def _handle_node_updated(module, client_factory, blueprint_id):
     else:
         node_ids = list(node_id)
 
-    # Resolve each entry: label → graph-node UUID via system node resolution
-    resolved_ids = []
-    for nid in node_ids:
-        try:
-            resolved = resolve_system_node_id(client_factory, blueprint_id, nid)
-        except ValueError as exc:
-            module.fail_json(msg=str(exc))
-        resolved_ids.append((nid, resolved))
+    # Resolve each entry: label → graph-node UUID via system/rack node resolution
+    # Skip resolution if node_id was already resolved from current_label
+    if node_id_already_resolved:
+        resolved_ids = [(nid, nid) for nid in node_ids]
+    else:
+        resolved_ids = []
+        for nid in node_ids:
+            try:
+                if node_type == "rack":
+                    resolved = resolve_rack_node_id(client_factory, blueprint_id, nid)
+                else:
+                    resolved = resolve_system_node_id(client_factory, blueprint_id, nid)
+            except ValueError as exc:
+                module.fail_json(msg=str(exc))
+            resolved_ids.append((nid, resolved))
 
     # Build desired fields from params
     desired = {}

--- a/ansible_collections/juniper/apstra/tests/blueprint.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint.yml
@@ -294,6 +294,7 @@
         id: "{{ bp_assign.id }}"
         rack_id: "{{ rack_node_id }}"
         rack_label: "rack-test-baseline"
+        node_type: rack
         state: node_updated
         auth_token: "{{ auth.token }}"
 
@@ -341,6 +342,7 @@
         id: "{{ bp_assign.id }}"
         rack_id: "{{ rack_node_id }}"
         rack_label: "rack-by-uuid"
+        node_type: rack
         state: node_updated
         auth_token: "{{ auth.token }}"
       register: rack_rename_by_id
@@ -358,6 +360,7 @@
         id: "{{ bp_assign.id }}"
         rack_id: "{{ rack_node_id }}"
         rack_label: "{{ rack_original_label }}"
+        node_type: rack
         state: node_updated
         auth_token: "{{ auth.token }}"
       register: rack_restore


### PR DESCRIPTION
Bug
---
The _handle_node_updated refactor introduced a resolve loop that called resolve_system_node_id() on every node_id, including those already resolved from current_label and those targeting rack nodes. This caused two distinct failures:

1. rack_id (node_id alias) path: passing a rack graph-node ID to resolve_system_node_id() failed because it only queries node('system', ...), so rack nodes were never found:

     "System node 'EuYqsguLfD6LIvyWRg' not found in blueprint.
      Available: ['spine1', 'leaf1', ...]"

2. current_label path: list_nodes() correctly resolves any node type (racks, redundancy groups, ES-pair leaves, etc.) to a graph-node ID, but that resolved ID was then re-fed into resolve_system_node_id(), failing for any non-system node:

     "System node 'rack_leaf_new_001_leaf_pair1' not found in blueprint."

Fix
---
- Add node_id_already_resolved flag: when current_label is used, the resolved node_id bypasses the secondary resolution loop entirely.
- In the direct node_id path, route to resolve_rack_node_id() when node_type == "rack", matching the existing current_label branch.
- Add node_type: rack to the three test tasks in blueprint.yml that use rack_id directly (pre-test baseline reset, RACK-3, RACK-4) so the module knows to use rack resolution for those calls.

Tested
------
make test-blueprint: 52 tasks, 0 failures
- All rack rename tests pass (RACK-1 through RACK-5)
- Idempotency verified for rack and system node paths
- current_label works for any node type without node_type parameter