### PR TITLE
fix(interconnect_gateway): merge VN/SZ settings instead of replacing on PATCH

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interconnect_gateway.py
@@ -546,6 +546,23 @@ def _run_domain(module, client_factory, result):
                     get_interconnect_domain(client_factory, blueprint_id, domain_id)
                     or {}
                 )
+
+                # Merge user-specified VNs/security-zones with existing
+                # ones so that a PATCH for new entries does not remove
+                # previously configured entries.  User-specified values
+                # override existing ones for the same key.
+                _MERGE_KEYS = (
+                    "interconnect_virtual_networks",
+                    "interconnect_security_zones",
+                )
+                for mk in _MERGE_KEYS:
+                    if mk in patch_payload and isinstance(patch_payload[mk], dict):
+                        existing = cur.get(mk, {})
+                        if isinstance(existing, dict):
+                            merged = dict(existing)
+                            merged.update(patch_payload[mk])
+                            patch_payload[mk] = merged
+
                 needs_patch = False
                 for k, desired in patch_payload.items():
                     current = cur.get(k, {})


### PR DESCRIPTION
Previously, when updating virtual_networks or security_zones on an interconnect domain, the module sent only the user-specified entries in the PATCH payload. The Apstra API treats this as a full replacement, causing all previously configured VN connection types (L2/L3) and security zone settings to be silently disabled.

Now the module fetches the current domain state and merges existing interconnect_virtual_networks and interconnect_security_zones entries with the user-specified ones before sending the PATCH. User-specified values override existing ones for the same key, but entries not mentioned in the current task are preserved.