### PR TITLE
feat: rack management add or remove racks in blueprint

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/name_resolution.py
@@ -156,6 +156,60 @@ def resolve_template_id(client_factory, template_ref):
     )
 
 
+def resolve_rack_type_id(client_factory, rack_type_ref):
+    """Resolve a rack type reference (ID or display_name) to its design ID.
+
+    :param client_factory: An ``ApstraClientFactory`` instance.
+    :param rack_type_ref: The rack type ID or display_name.
+    :return: The resolved rack type ID string.
+    :raises ValueError: If no matching rack type is found.
+    """
+    if not rack_type_ref:
+        return rack_type_ref
+
+    base = client_factory.get_base_client()
+    resp = base.raw_request("/design/rack-types")
+    if resp.status_code != 200:
+        raise Exception(f"Failed to list rack types: {resp.status_code} {resp.text}")
+    try:
+        data = resp.json()
+    except Exception:
+        data = {}
+    rack_types = data.get("items", [])
+
+    # 1. Exact ID match (fast path — already a valid ID)
+    for rt in rack_types:
+        if rt.get("id") == rack_type_ref:
+            return rack_type_ref
+
+    # 2. Exact display_name match
+    for rt in rack_types:
+        if rt.get("display_name") == rack_type_ref:
+            return rt["id"]
+
+    # 3. Case-insensitive display_name match
+    ref_lower = rack_type_ref.lower()
+    matches = [
+        rt for rt in rack_types if (rt.get("display_name") or "").lower() == ref_lower
+    ]
+    if len(matches) == 1:
+        return matches[0]["id"]
+    if len(matches) > 1:
+        ids = [m["id"] for m in matches]
+        raise ValueError(
+            f"Multiple rack types match '{rack_type_ref}': {ids}. "
+            "Use the exact rack type ID instead."
+        )
+
+    available = [
+        f"  - {rt.get('id')!r} ({rt.get('display_name', '')})" for rt in rack_types
+    ]
+    raise ValueError(
+        f"Rack type '{rack_type_ref}' not found. "
+        f"Available rack types:\n" + "\n".join(available)
+    )
+
+
 def resolve_system_node_ids(client_factory, blueprint_id, node_refs):
     """Resolve a list of system node references to their graph node IDs.
 

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -643,15 +643,43 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolut
 def _get_racks_by_type(client_factory, blueprint_id, rack_type_id):
     """Return rack node dicts from the blueprint filtered by rack_type_id.
 
-    Uses the QE graph query so no separate REST call is required.  Each
-    rack node is expected to carry a ``rack_type_id`` property; nodes
-    without that property are excluded from the filtered result.
+    Blueprint rack nodes store the full rack type definition as the JSON
+    string ``rack_type_json``.  The ``id`` inside that JSON is a content
+    hash, not the design-API rack type ID.  We look up the rack type's
+    ``display_name`` via the design API and match against
+    ``rack_type_json.display_name`` to filter correctly.
     """
+    import json as _json
+
     items = run_qe_query(client_factory, blueprint_id, "node('rack', name='rack')")
     racks = [r.get("rack", {}) for r in items if r.get("rack")]
-    if rack_type_id:
-        racks = [r for r in racks if r.get("rack_type_id") == rack_type_id]
-    return racks
+    if not rack_type_id:
+        return racks
+
+    # Resolve the design-API display_name for this rack_type_id.
+    base = client_factory.get_base_client()
+    resp = base.raw_request("/design/rack-types")
+    design_display_name = None
+    if resp.status_code == 200:
+        for rt in (resp.json() or {}).get("items", []):
+            if rt.get("id") == rack_type_id:
+                design_display_name = rt.get("display_name")
+                break
+
+    if not design_display_name:
+        # Cannot match by display_name — return unfiltered
+        return racks
+
+    filtered = []
+    for rack in racks:
+        rt_json_str = rack.get("rack_type_json")
+        if rt_json_str:
+            try:
+                if _json.loads(rt_json_str).get("display_name") == design_display_name:
+                    filtered.append(rack)
+            except Exception:
+                pass
+    return filtered
 
 
 # ──────────────────────────────────────────────────────────────────
@@ -690,10 +718,23 @@ def _handle_rack_added(module, client_factory, blueprint_id):
 
     to_add = rack_count - current_count
     base = client_factory.get_base_client()
+
+    # Fetch the full rack type definition required by the add-racks body
+    rt_resp = base.raw_request(f"/design/rack-types/{rack_type_id}")
+    if rt_resp.status_code != 200:
+        raise Exception(
+            f"Failed to fetch rack type definition for '{rack_type_id}': "
+            f"HTTP {rt_resp.status_code} — {rt_resp.text}"
+        )
+    rack_type_def = rt_resp.json()
+
     resp = base.raw_request(
-        f"/blueprints/{blueprint_id}/racks",
+        f"/blueprints/{blueprint_id}/add-racks",
         method="POST",
-        data={"rack_type_id": rack_type_id, "rack_count": to_add},
+        data={
+            "rack_types": [rack_type_def],
+            "rack_type_counts": {rack_type_id: to_add},
+        },
     )
     if resp.status_code not in (200, 201, 202):
         raise Exception(
@@ -741,18 +782,16 @@ def _handle_rack_deleted(module, client_factory, blueprint_id):
         )
 
     base = client_factory.get_base_client()
-    deleted = []
-    for orig_ref, resolved_id in resolved_ids:
-        resp = base.raw_request(
-            f"/blueprints/{blueprint_id}/racks/{resolved_id}",
-            method="DELETE",
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/delete-racks",
+        method="POST",
+        data={"racks_to_delete": [resolved_id for _, resolved_id in resolved_ids]},
+    )
+    if resp.status_code not in (200, 201, 202, 204):
+        raise Exception(
+            f"Failed to delete racks: " f"HTTP {resp.status_code} — {resp.text}"
         )
-        if resp.status_code not in (200, 202, 204):
-            raise Exception(
-                f"Failed to delete rack '{orig_ref}' ({resolved_id}): "
-                f"HTTP {resp.status_code} — {resp.text}"
-            )
-        deleted.append(resolved_id)
+    deleted = [resolved_id for _, resolved_id in resolved_ids]
 
     n = len(deleted)
     return dict(

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -83,6 +83,33 @@ options:
     required: false
     type: int
     default: 60
+  rack_type:
+    description:
+      - Rack type reference for C(state=rack_added).
+      - Accepts either rack type ID (for example C(L2_Virtual)) or display name
+        (for example C(L2 Virtual)).
+      - Required when C(state=rack_added).
+    type: str
+    required: false
+  rack_count:
+    description:
+      - Desired total number of racks of C(rack_type) to exist in the blueprint.
+      - Declarative/idempotent behavior: the module only adds missing racks until
+        the desired total is reached.
+      - Mutually exclusive with C(racks_to_add).
+      - Only used when C(state=rack_added).
+    type: int
+    required: false
+    default: 1
+  racks_to_add:
+    description:
+      - Number of racks to add in this run.
+      - Imperative/non-idempotent behavior (WebUI-style): each run adds this many
+        racks regardless of current count.
+      - Mutually exclusive with C(rack_count).
+      - Only used when C(state=rack_added).
+    type: int
+    required: false
   commit_timeout:
     description:
       - The timeout in seconds for committing the blueprint.
@@ -113,9 +140,12 @@ options:
       - C(node_updated) patches properties on one or more blueprint
         nodes. Use C(node_id) to target a single node by UUID, or
         C(assignment) to assign multiple nodes by label in one task.
+      - C(rack_added) adds racks of a rack type using either C(rack_count)
+        (desired total, idempotent) or C(racks_to_add) (delta, non-idempotent).
+      - C(rack_deleted) deletes rack(s) by C(rack_id) / C(node_id).
     required: false
     type: str
-    choices: ["present", "committed", "absent", "queried", "node_updated"]
+    choices: ["present", "committed", "absent", "queried", "node_updated", "rack_added", "rack_deleted"]
     default: "present"
   query:
     description:
@@ -449,18 +479,19 @@ EXAMPLES = """
     node_type: rack
     state: node_updated
 
-# Add 2 racks of a given rack type (by display name)
-- name: Add 2 racks of type 'AOS-2x10-1'
+
+# Add 2 racks (WebUI-style, non-idempotent)
+- name: Add 2 racks of type 'AOS-2x10-1' (non-idempotent)
   juniper.apstra.blueprint:
     id:
       blueprint: "{{ blueprint_id }}"
     rack_type: "AOS-2x10-1"
-    rack_count: 2
+    racks_to_add: 2
     state: rack_added
   register: racks_result
 
-# Add racks idempotently — re-run is safe (returns changed=false if already present)
-- name: Ensure at least 1 rack of type 'AOS-2x10-1' exists
+# Ensure at least 1 rack exists (idempotent)
+- name: Ensure at least 1 rack of type 'AOS-2x10-1' exists (idempotent)
   juniper.apstra.blueprint:
     id:
       blueprint: "{{ blueprint_id }}"
@@ -690,16 +721,64 @@ def _get_racks_by_type(client_factory, blueprint_id, rack_type_id):
 def _handle_rack_added(module, client_factory, blueprint_id):
     """Handle state=rack_added — add racks of a given type to the blueprint."""
     rack_type_ref = module.params.get("rack_type")
-    rack_count = module.params.get("rack_count") or 1
+    rack_count = module.params.get("rack_count")
+    racks_to_add = module.params.get("racks_to_add")
 
     if not rack_type_ref:
         module.fail_json(msg="rack_type is required when state=rack_added")
+
+    if rack_count is not None and racks_to_add is not None:
+        module.fail_json(
+            msg="rack_count and racks_to_add are mutually exclusive. Use only one."
+        )
 
     # Resolve rack type name/display_name → design ID
     try:
         rack_type_id = resolve_rack_type_id(client_factory, rack_type_ref)
     except (ValueError, Exception) as exc:
         module.fail_json(msg=str(exc))
+
+    base = client_factory.get_base_client()
+
+    # Non-idempotent: racks_to_add (WebUI style)
+    if racks_to_add is not None:
+        if racks_to_add < 1:
+            module.fail_json(msg="racks_to_add must be >= 1 if specified.")
+        # Fetch the full rack type definition required by the add-racks body
+        rt_resp = base.raw_request(f"/design/rack-types/{rack_type_id}")
+        if rt_resp.status_code != 200:
+            raise Exception(
+                f"Failed to fetch rack type definition for '{rack_type_id}': "
+                f"HTTP {rt_resp.status_code} — {rt_resp.text}"
+            )
+        rack_type_def = rt_resp.json()
+        resp = base.raw_request(
+            f"/blueprints/{blueprint_id}/add-racks",
+            method="POST",
+            data={
+                "rack_types": [rack_type_def],
+                "rack_type_counts": {rack_type_id: racks_to_add},
+            },
+        )
+        if resp.status_code not in (200, 201, 202):
+            raise Exception(
+                f"Failed to add racks to blueprint: HTTP {resp.status_code} — {resp.text}"
+            )
+        all_racks = _get_racks_by_type(client_factory, blueprint_id, rack_type_id)
+        return dict(
+            changed=True,
+            racks=all_racks,
+            racks_added=racks_to_add,
+            rack_type_id=rack_type_id,
+            msg=(
+                f"Added {racks_to_add} rack(s) of type '{rack_type_ref}' to blueprint "
+                f"(total: {len(all_racks)})"
+            ),
+        )
+
+    # Idempotent: rack_count (Ansible style, default)
+    if rack_count is None:
+        rack_count = 1
 
     # Idempotency check: count existing racks of this type in the blueprint
     existing = _get_racks_by_type(client_factory, blueprint_id, rack_type_id)
@@ -717,8 +796,6 @@ def _handle_rack_added(module, client_factory, blueprint_id):
         )
 
     to_add = rack_count - current_count
-    base = client_factory.get_base_client()
-
     # Fetch the full rack type definition required by the add-racks body
     rt_resp = base.raw_request(f"/design/rack-types/{rack_type_id}")
     if rt_resp.status_code != 200:
@@ -727,7 +804,6 @@ def _handle_rack_added(module, client_factory, blueprint_id):
             f"HTTP {rt_resp.status_code} — {rt_resp.text}"
         )
     rack_type_def = rt_resp.json()
-
     resp = base.raw_request(
         f"/blueprints/{blueprint_id}/add-racks",
         method="POST",
@@ -740,7 +816,6 @@ def _handle_rack_added(module, client_factory, blueprint_id):
         raise Exception(
             f"Failed to add racks to blueprint: HTTP {resp.status_code} — {resp.text}"
         )
-
     all_racks = _get_racks_by_type(client_factory, blueprint_id, rack_type_id)
     return dict(
         changed=True,
@@ -1191,7 +1266,8 @@ def main():
         ),
         # Rack management params (state=rack_added / rack_deleted)
         rack_type=dict(type="str", required=False),
-        rack_count=dict(type="int", required=False, default=1),
+        rack_count=dict(type="int", required=False),
+        racks_to_add=dict(type="int", required=False),
         # Query params (state=queried)
         query=dict(type="str", required=False),
         query_type=dict(

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -448,6 +448,41 @@ EXAMPLES = """
     rack_label: "border-rack-1"
     node_type: rack
     state: node_updated
+
+# Add 2 racks of a given rack type (by display name)
+- name: Add 2 racks of type 'AOS-2x10-1'
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    rack_type: "AOS-2x10-1"
+    rack_count: 2
+    state: rack_added
+  register: racks_result
+
+# Add racks idempotently — re-run is safe (returns changed=false if already present)
+- name: Ensure at least 1 rack of type 'AOS-2x10-1' exists
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    rack_type: "AOS-2x10-1"
+    rack_count: 1
+    state: rack_added
+
+# Delete a rack by its blueprint rack ID
+- name: Remove a rack from the blueprint
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    rack_id: "{{ rack_node_id }}"
+    state: rack_deleted
+
+# Delete a rack by its label (name resolution handled automatically)
+- name: Remove rack by label
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    rack_id: "da_rack_001"
+    state: rack_deleted
 """
 
 RETURN = """
@@ -534,6 +569,33 @@ node:
         - Returned by C(state=node_updated).
     returned: when using node_updated
     type: dict
+racks:
+    description:
+        - List of rack dicts currently in the blueprint for the requested
+          rack type after the operation.
+        - Returned by C(state=rack_added).
+    returned: when using rack_added
+    type: list
+    elements: dict
+racks_added:
+    description:
+        - Number of racks added during this run.
+        - Returned by C(state=rack_added) when C(changed=true).
+    returned: when racks were added
+    type: int
+rack_type_id:
+    description:
+        - Resolved rack type ID used for the operation.
+        - Returned by C(state=rack_added).
+    returned: when using rack_added
+    type: str
+racks_deleted:
+    description:
+        - List of rack node IDs that were deleted.
+        - Returned by C(state=rack_deleted) when C(changed=true).
+    returned: when racks were deleted
+    type: list
+    elements: str
 """
 
 from time import sleep
@@ -566,10 +628,138 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes imp
 
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
     resolve_template_id as _resolve_template_id,
+    resolve_rack_type_id,
     resolve_graph_node_id,
     resolve_rack_node_id,
     resolve_system_node_id,
 )
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Rack management helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+def _get_racks_by_type(client_factory, blueprint_id, rack_type_id):
+    """Return rack node dicts from the blueprint filtered by rack_type_id.
+
+    Uses the QE graph query so no separate REST call is required.  Each
+    rack node is expected to carry a ``rack_type_id`` property; nodes
+    without that property are excluded from the filtered result.
+    """
+    items = run_qe_query(client_factory, blueprint_id, "node('rack', name='rack')")
+    racks = [r.get("rack", {}) for r in items if r.get("rack")]
+    if rack_type_id:
+        racks = [r for r in racks if r.get("rack_type_id") == rack_type_id]
+    return racks
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Rack management handlers (state=rack_added / state=rack_deleted)
+# ──────────────────────────────────────────────────────────────────
+
+
+def _handle_rack_added(module, client_factory, blueprint_id):
+    """Handle state=rack_added — add racks of a given type to the blueprint."""
+    rack_type_ref = module.params.get("rack_type")
+    rack_count = module.params.get("rack_count") or 1
+
+    if not rack_type_ref:
+        module.fail_json(msg="rack_type is required when state=rack_added")
+
+    # Resolve rack type name/display_name → design ID
+    try:
+        rack_type_id = resolve_rack_type_id(client_factory, rack_type_ref)
+    except (ValueError, Exception) as exc:
+        module.fail_json(msg=str(exc))
+
+    # Idempotency check: count existing racks of this type in the blueprint
+    existing = _get_racks_by_type(client_factory, blueprint_id, rack_type_id)
+    current_count = len(existing)
+
+    if current_count >= rack_count:
+        return dict(
+            changed=False,
+            racks=existing,
+            rack_type_id=rack_type_id,
+            msg=(
+                f"Blueprint already has {current_count} rack(s) of type "
+                f"'{rack_type_ref}' (desired: {rack_count}). No changes needed."
+            ),
+        )
+
+    to_add = rack_count - current_count
+    base = client_factory.get_base_client()
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/racks",
+        method="POST",
+        data={"rack_type_id": rack_type_id, "rack_count": to_add},
+    )
+    if resp.status_code not in (200, 201, 202):
+        raise Exception(
+            f"Failed to add racks to blueprint: HTTP {resp.status_code} — {resp.text}"
+        )
+
+    all_racks = _get_racks_by_type(client_factory, blueprint_id, rack_type_id)
+    return dict(
+        changed=True,
+        racks=all_racks,
+        racks_added=to_add,
+        rack_type_id=rack_type_id,
+        msg=(
+            f"Added {to_add} rack(s) of type '{rack_type_ref}' to blueprint "
+            f"(total: {len(all_racks)})"
+        ),
+    )
+
+
+def _handle_rack_deleted(module, client_factory, blueprint_id):
+    """Handle state=rack_deleted — remove rack(s) from the blueprint."""
+    # node_id has alias rack_id (defined in argspec)
+    rack_id = module.params.get("node_id")
+
+    if not rack_id:
+        module.fail_json(msg="rack_id is required when state=rack_deleted")
+
+    rack_ids = [rack_id] if isinstance(rack_id, str) else list(rack_id)
+
+    # Resolve each reference (label or UUID) to a blueprint rack node ID.
+    # Racks that cannot be found are silently skipped (idempotency).
+    resolved_ids = []
+    for rid in rack_ids:
+        try:
+            resolved = resolve_rack_node_id(client_factory, blueprint_id, rid)
+            resolved_ids.append((rid, resolved))
+        except ValueError:
+            pass  # already deleted or never existed
+
+    if not resolved_ids:
+        return dict(
+            changed=False,
+            racks_deleted=[],
+            msg="Rack(s) not found in blueprint (already deleted or never existed)",
+        )
+
+    base = client_factory.get_base_client()
+    deleted = []
+    for orig_ref, resolved_id in resolved_ids:
+        resp = base.raw_request(
+            f"/blueprints/{blueprint_id}/racks/{resolved_id}",
+            method="DELETE",
+        )
+        if resp.status_code not in (200, 202, 204):
+            raise Exception(
+                f"Failed to delete rack '{orig_ref}' ({resolved_id}): "
+                f"HTTP {resp.status_code} — {resp.text}"
+            )
+        deleted.append(resolved_id)
+
+    n = len(deleted)
+    return dict(
+        changed=True,
+        racks_deleted=deleted,
+        msg=f"Deleted {n} rack(s) from blueprint",
+    )
 
 
 # ──────────────────────────────────────────────────────────────────
@@ -949,9 +1139,20 @@ def main():
         state=dict(
             type="str",
             required=False,
-            choices=["present", "committed", "absent", "queried", "node_updated"],
+            choices=[
+                "present",
+                "committed",
+                "absent",
+                "queried",
+                "node_updated",
+                "rack_added",
+                "rack_deleted",
+            ],
             default="present",
         ),
+        # Rack management params (state=rack_added / rack_deleted)
+        rack_type=dict(type="str", required=False),
+        rack_count=dict(type="int", required=False, default=1),
         # Query params (state=queried)
         query=dict(type="str", required=False),
         query_type=dict(
@@ -1034,6 +1235,22 @@ def main():
             if not blueprint_id:
                 module.fail_json(msg="id.blueprint is required when state=node_updated")
             result = _handle_node_updated(module, client_factory, blueprint_id)
+            module.exit_json(**result)
+            return
+
+        # ── state=rack_added ─────────────────────────────────────
+        if state == "rack_added":
+            if not blueprint_id:
+                module.fail_json(msg="id.blueprint is required when state=rack_added")
+            result = _handle_rack_added(module, client_factory, blueprint_id)
+            module.exit_json(**result)
+            return
+
+        # ── state=rack_deleted ────────────────────────────────────
+        if state == "rack_deleted":
+            if not blueprint_id:
+                module.fail_json(msg="id.blueprint is required when state=rack_deleted")
+            result = _handle_rack_deleted(module, client_factory, blueprint_id)
             module.exit_json(**result)
             return
 

--- a/ansible_collections/juniper/apstra/tests/blueprint.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint.yml
@@ -482,8 +482,81 @@
         msg: "Discovered rack_type_ref='{{ existing_rack_type_ref }}', rack_node_id={{ existing_rack_node_id }}, initial_rack_count={{ initial_rack_count }}"
       when: existing_rack_type_ref is defined
 
+
+    # ── TEST RACK_ADD-DELTA-1 (WebUI-style, non-idempotent) ─────────────
+    - name: "[TEST RACK_ADD-DELTA-1] Capture rack IDs before racks_to_add"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        query: "node('rack', name='rack')"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: rack_qe_before_delta_add
+
+    - name: "[TEST RACK_ADD-DELTA-1] Add 1 rack using racks_to_add"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        rack_type: "{{ existing_rack_type_ref }}"
+        racks_to_add: 1
+        state: rack_added
+        auth_token: "{{ auth.token }}"
+      register: rack_add_delta1
+      when: existing_rack_type_ref is defined and existing_rack_type_ref | length > 0
+
+    - name: "[TEST RACK_ADD-DELTA-1] Verify 1 rack was added and changed=true"
+      ansible.builtin.assert:
+        that:
+          - rack_add_delta1 is defined
+          - rack_add_delta1 is success
+          - rack_add_delta1.changed
+          - rack_add_delta1.racks_added == 1
+        fail_msg: "FAILED: racks_to_add did not add 1 rack (changed={{ rack_add_delta1.changed }}, racks_added={{ rack_add_delta1.racks_added }})"
+        success_msg: "PASSED: racks_to_add added 1 rack (changed=true)"
+      when: rack_add_delta1 is defined
+
+    - name: "[TEST RACK_ADD-DELTA-1] Capture rack IDs after racks_to_add"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        query: "node('rack', name='rack')"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: rack_qe_after_delta_add
+
+    - name: "[TEST RACK_ADD-DELTA-1] Identify newly added rack candidate IDs"
+      ansible.builtin.set_fact:
+        rack_added_by_delta_candidates: "{{ (rack_qe_after_delta_add.results | map(attribute='rack') | map(attribute='id') | list) | difference(rack_qe_before_delta_add.results | map(attribute='rack') | map(attribute='id') | list) }}"
+
+    - name: "[TEST RACK_ADD-DELTA-1] Verify exactly one new rack ID was discovered"
+      ansible.builtin.assert:
+        that:
+          - rack_added_by_delta_candidates | length == 1
+        fail_msg: "FAILED: Expected exactly 1 new rack after racks_to_add, got {{ rack_added_by_delta_candidates | length }}"
+        success_msg: "PASSED: Identified exactly one newly added rack candidate"
+
+    - name: "[TEST RACK_ADD-DELTA-1] Save newly added rack ID"
+      ansible.builtin.set_fact:
+        rack_added_by_delta: "{{ rack_added_by_delta_candidates[0] }}"
+
+    - name: "[TEST RACK_ADD-DELTA-1] Delete the newly added rack"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        rack_id: "{{ rack_added_by_delta }}"
+        state: rack_deleted
+        auth_token: "{{ auth.token }}"
+      register: rack_del_delta1
+
+    - name: "[TEST RACK_ADD-DELTA-1] Verify the newly added rack was deleted"
+      ansible.builtin.assert:
+        that:
+          - rack_del_delta1 is defined
+          - rack_del_delta1 is success
+          - rack_del_delta1.changed
+          - rack_del_delta1.racks_deleted | length == 1
+          - rack_added_by_delta in rack_del_delta1.racks_deleted
+        fail_msg: "FAILED: Could not delete the rack added by racks_to_add"
+        success_msg: "PASSED: Deleted rack added by racks_to_add and continued"
+
     # ── TEST RACK_ADD-1 ───────────────────────────────────────────────────
-    - name: "[TEST RACK_ADD-1] Ensure blueprint has (initial+1) racks — rack_count is desired total, not delta"
+    - name: "[TEST RACK_ADD-1] Ensure blueprint has (initial+1) racks — rack_count is desired total, not delta (idempotent)"
       juniper.apstra.blueprint:
         id: "{{ bp_rack.id }}"
         rack_type: "{{ existing_rack_type_ref }}"
@@ -492,11 +565,6 @@
         auth_token: "{{ auth.token }}"
       register: rack_add1
       when: existing_rack_type_ref is defined and existing_rack_type_ref | length > 0
-
-    - name: "[TEST RACK_ADD-1] Show result"
-      ansible.builtin.debug:
-        var: rack_add1
-      when: rack_add1 is defined
 
     - name: "[TEST RACK_ADD-1] Verify racks were added and changed=true"
       ansible.builtin.assert:

--- a/ansible_collections/juniper/apstra/tests/blueprint.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint.yml
@@ -483,7 +483,7 @@
       when: existing_rack_type_ref is defined
 
     # ── TEST RACK_ADD-1 ───────────────────────────────────────────────────
-    - name: "[TEST RACK_ADD-1] Add racks to exceed initial count (tests actual API call)"
+    - name: "[TEST RACK_ADD-1] Ensure blueprint has (initial+1) racks — rack_count is desired total, not delta"
       juniper.apstra.blueprint:
         id: "{{ bp_rack.id }}"
         rack_type: "{{ existing_rack_type_ref }}"
@@ -510,7 +510,7 @@
       when: rack_add1 is defined
 
     # ── TEST RACK_ADD-2 (idempotency) ────────────────────────────────────
-    - name: "[TEST RACK_ADD-2] Re-run rack_added with same count (idempotency)"
+    - name: "[TEST RACK_ADD-2] Re-run with same desired total — no change (idempotency)"
       juniper.apstra.blueprint:
         id: "{{ bp_rack.id }}"
         rack_type: "{{ existing_rack_type_ref }}"
@@ -531,7 +531,7 @@
       when: rack_add2 is defined
 
     # ── TEST RACK_ADD-3 (lower count — still idempotent) ─────────────────
-    - name: "[TEST RACK_ADD-3] rack_added with smaller count than current — no change"
+    - name: "[TEST RACK_ADD-3] Desired total below current count — no change (already satisfied)"
       juniper.apstra.blueprint:
         id: "{{ bp_rack.id }}"
         rack_type: "{{ existing_rack_type_ref }}"

--- a/ansible_collections/juniper/apstra/tests/blueprint.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint.yml
@@ -403,6 +403,32 @@
     #  Rack management tests (state=rack_added, state=rack_deleted)
     # ─────────────────────────────────────────────────────────────────────
 
+    - name: "[RACK SETUP] Find leftover rack test blueprint from prior runs"
+      juniper.apstra.blueprint:
+        body:
+          label: "{{ blueprint_name }}_rack_test"
+          design: "two_stage_l3clos"
+          init_type: "template_reference"
+          template_id: "L2 Virtual EVPN"
+        lock_state: ignore
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: bp_rack_stale
+      ignore_errors: true
+
+    - name: "[RACK SETUP] Delete leftover rack test blueprint if found"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack_stale.id }}"
+        lock_state: ignore
+        state: absent
+        auth_token: "{{ auth.token }}"
+      when:
+        - bp_rack_stale is success
+        - bp_rack_stale.id is defined
+        - bp_rack_stale.id.blueprint is defined
+        - bp_rack_stale.id.blueprint | length > 0
+      ignore_errors: true
+
     - name: "[RACK SETUP] Create L2-EVPN blueprint for rack management tests"
       juniper.apstra.blueprint:
         body:
@@ -443,28 +469,28 @@
 
     - name: "[RACK SETUP] Save first existing rack info for later tests"
       ansible.builtin.set_fact:
-        existing_rack: "{{ rack_qe_result.nodes[0].rack }}"
-        existing_rack_type_id: "{{ rack_qe_result.nodes[0].rack.rack_type_id | default('') }}"
-        existing_rack_node_id: "{{ rack_qe_result.nodes[0].rack.id }}"
+        existing_rack: "{{ rack_qe_result.results[0].rack }}"
+        existing_rack_type_ref: "{{ (rack_qe_result.results[0].rack.rack_type_json | from_json).display_name | default('') }}"
+        existing_rack_node_id: "{{ rack_qe_result.results[0].rack.id }}"
       when:
         - rack_qe_result is success
-        - rack_qe_result.nodes | length > 0
+        - rack_qe_result.results | length > 0
 
-    - name: "[RACK SETUP] Show discovered rack_type_id"
+    - name: "[RACK SETUP] Show discovered rack type display_name"
       ansible.builtin.debug:
-        msg: "Discovered rack_type_id={{ existing_rack_type_id }}, rack_node_id={{ existing_rack_node_id }}"
-      when: existing_rack_type_id is defined
+        msg: "Discovered rack_type_ref='{{ existing_rack_type_ref }}', rack_node_id={{ existing_rack_node_id }}"
+      when: existing_rack_type_ref is defined
 
     # ── TEST RACK_ADD-1 ───────────────────────────────────────────────────
     - name: "[TEST RACK_ADD-1] Add 1 rack by rack_type_id"
       juniper.apstra.blueprint:
         id: "{{ bp_rack.id }}"
-        rack_type: "{{ existing_rack_type_id }}"
+        rack_type: "{{ existing_rack_type_ref }}"
         rack_count: 3
         state: rack_added
         auth_token: "{{ auth.token }}"
       register: rack_add1
-      when: existing_rack_type_id is defined and existing_rack_type_id | length > 0
+      when: existing_rack_type_ref is defined and existing_rack_type_ref | length > 0
 
     - name: "[TEST RACK_ADD-1] Show result"
       ansible.builtin.debug:
@@ -476,7 +502,6 @@
         that:
           - rack_add1 is defined
           - rack_add1 is success
-          - rack_add1.rack_type_id == existing_rack_type_id
           - rack_add1.racks | length >= 3
         fail_msg: "FAILED: rack_added did not return expected results"
         success_msg: "PASSED: rack_added succeeded, racks={{ rack_add1.racks | length }}"
@@ -486,12 +511,12 @@
     - name: "[TEST RACK_ADD-2] Re-run rack_added with same count (idempotency)"
       juniper.apstra.blueprint:
         id: "{{ bp_rack.id }}"
-        rack_type: "{{ existing_rack_type_id }}"
+        rack_type: "{{ existing_rack_type_ref }}"
         rack_count: 3
         state: rack_added
         auth_token: "{{ auth.token }}"
       register: rack_add2
-      when: existing_rack_type_id is defined and existing_rack_type_id | length > 0
+      when: existing_rack_type_ref is defined and existing_rack_type_ref | length > 0
 
     - name: "[TEST RACK_ADD-2] Verify idempotency"
       ansible.builtin.assert:
@@ -507,12 +532,12 @@
     - name: "[TEST RACK_ADD-3] rack_added with smaller count than current — no change"
       juniper.apstra.blueprint:
         id: "{{ bp_rack.id }}"
-        rack_type: "{{ existing_rack_type_id }}"
+        rack_type: "{{ existing_rack_type_ref }}"
         rack_count: 1
         state: rack_added
         auth_token: "{{ auth.token }}"
       register: rack_add3
-      when: existing_rack_type_id is defined and existing_rack_type_id | length > 0
+      when: existing_rack_type_ref is defined and existing_rack_type_ref | length > 0
 
     - name: "[TEST RACK_ADD-3] Verify no change when below current count"
       ansible.builtin.assert:
@@ -554,10 +579,10 @@
 
     - name: "[TEST RACK_DEL-1] Save the last rack's node_id for deletion"
       ansible.builtin.set_fact:
-        rack_to_delete: "{{ rack_qe_before_del.nodes[-1].rack.id }}"
+        rack_to_delete: "{{ rack_qe_before_del.results[-1].rack.id }}"
       when:
         - rack_qe_before_del is success
-        - rack_qe_before_del.nodes | length > 0
+        - rack_qe_before_del.results | length > 0
 
     - name: "[TEST RACK_DEL-1] Delete the rack by node ID"
       juniper.apstra.blueprint:

--- a/ansible_collections/juniper/apstra/tests/blueprint.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint.yml
@@ -472,21 +472,22 @@
         existing_rack: "{{ rack_qe_result.results[0].rack }}"
         existing_rack_type_ref: "{{ (rack_qe_result.results[0].rack.rack_type_json | from_json).display_name | default('') }}"
         existing_rack_node_id: "{{ rack_qe_result.results[0].rack.id }}"
+        initial_rack_count: "{{ rack_qe_result.results | length }}"
       when:
         - rack_qe_result is success
         - rack_qe_result.results | length > 0
 
     - name: "[RACK SETUP] Show discovered rack type display_name"
       ansible.builtin.debug:
-        msg: "Discovered rack_type_ref='{{ existing_rack_type_ref }}', rack_node_id={{ existing_rack_node_id }}"
+        msg: "Discovered rack_type_ref='{{ existing_rack_type_ref }}', rack_node_id={{ existing_rack_node_id }}, initial_rack_count={{ initial_rack_count }}"
       when: existing_rack_type_ref is defined
 
     # ── TEST RACK_ADD-1 ───────────────────────────────────────────────────
-    - name: "[TEST RACK_ADD-1] Add 1 rack by rack_type_id"
+    - name: "[TEST RACK_ADD-1] Add racks to exceed initial count (tests actual API call)"
       juniper.apstra.blueprint:
         id: "{{ bp_rack.id }}"
         rack_type: "{{ existing_rack_type_ref }}"
-        rack_count: 3
+        rack_count: "{{ initial_rack_count | int + 1 }}"
         state: rack_added
         auth_token: "{{ auth.token }}"
       register: rack_add1
@@ -497,14 +498,15 @@
         var: rack_add1
       when: rack_add1 is defined
 
-    - name: "[TEST RACK_ADD-1] Verify rack was added"
+    - name: "[TEST RACK_ADD-1] Verify racks were added and changed=true"
       ansible.builtin.assert:
         that:
           - rack_add1 is defined
           - rack_add1 is success
-          - rack_add1.racks | length >= 3
-        fail_msg: "FAILED: rack_added did not return expected results"
-        success_msg: "PASSED: rack_added succeeded, racks={{ rack_add1.racks | length }}"
+          - rack_add1.changed
+          - rack_add1.racks_added == 1
+        fail_msg: "FAILED: rack_added did not add racks (changed={{ rack_add1.changed }}, racks_added={{ rack_add1.racks_added }})"
+        success_msg: "PASSED: rack_added succeeded, racks_added={{ rack_add1.racks_added }}, total={{ rack_add1.racks | length }}, changed={{ rack_add1.changed }}"
       when: rack_add1 is defined
 
     # ── TEST RACK_ADD-2 (idempotency) ────────────────────────────────────
@@ -512,7 +514,7 @@
       juniper.apstra.blueprint:
         id: "{{ bp_rack.id }}"
         rack_type: "{{ existing_rack_type_ref }}"
-        rack_count: 3
+        rack_count: "{{ initial_rack_count | int + 1 }}"
         state: rack_added
         auth_token: "{{ auth.token }}"
       register: rack_add2

--- a/ansible_collections/juniper/apstra/tests/blueprint.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint.yml
@@ -399,6 +399,214 @@
         state: absent
         auth_token: "{{ auth.token }}"
 
+    # ─────────────────────────────────────────────────────────────────────
+    #  Rack management tests (state=rack_added, state=rack_deleted)
+    # ─────────────────────────────────────────────────────────────────────
+
+    - name: "[RACK SETUP] Create L2-EVPN blueprint for rack management tests"
+      juniper.apstra.blueprint:
+        body:
+          label: "{{ blueprint_name }}_rack_test"
+          design: "two_stage_l3clos"
+          init_type: "template_reference"
+          template_id: "L2 Virtual EVPN"
+        lock_state: locked
+        auth_token: "{{ auth.token }}"
+      register: bp_rack
+
+    - name: "[RACK SETUP] Save rack test blueprint ID"
+      ansible.builtin.set_fact:
+        rack_bp_id: "{{ bp_rack.id.blueprint }}"
+
+    - name: "[RACK SETUP] Query initial racks in blueprint"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        query_type: "nodes_by_type"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      ignore_errors: true
+      register: rack_initial_query
+
+    - name: "[RACK SETUP] Get available rack types from design"
+      juniper.apstra.authenticate:
+        logout: false
+      register: auth_check
+
+    # Use the raw QE approach to discover rack types already in the blueprint
+    - name: "[RACK SETUP] Query racks via QE to discover rack_type_id"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        query: "node('rack', name='rack')"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: rack_qe_result
+
+    - name: "[RACK SETUP] Save first existing rack info for later tests"
+      ansible.builtin.set_fact:
+        existing_rack: "{{ rack_qe_result.nodes[0].rack }}"
+        existing_rack_type_id: "{{ rack_qe_result.nodes[0].rack.rack_type_id | default('') }}"
+        existing_rack_node_id: "{{ rack_qe_result.nodes[0].rack.id }}"
+      when:
+        - rack_qe_result is success
+        - rack_qe_result.nodes | length > 0
+
+    - name: "[RACK SETUP] Show discovered rack_type_id"
+      ansible.builtin.debug:
+        msg: "Discovered rack_type_id={{ existing_rack_type_id }}, rack_node_id={{ existing_rack_node_id }}"
+      when: existing_rack_type_id is defined
+
+    # ── TEST RACK_ADD-1 ───────────────────────────────────────────────────
+    - name: "[TEST RACK_ADD-1] Add 1 rack by rack_type_id"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        rack_type: "{{ existing_rack_type_id }}"
+        rack_count: 3
+        state: rack_added
+        auth_token: "{{ auth.token }}"
+      register: rack_add1
+      when: existing_rack_type_id is defined and existing_rack_type_id | length > 0
+
+    - name: "[TEST RACK_ADD-1] Show result"
+      ansible.builtin.debug:
+        var: rack_add1
+      when: rack_add1 is defined
+
+    - name: "[TEST RACK_ADD-1] Verify rack was added"
+      ansible.builtin.assert:
+        that:
+          - rack_add1 is defined
+          - rack_add1 is success
+          - rack_add1.rack_type_id == existing_rack_type_id
+          - rack_add1.racks | length >= 3
+        fail_msg: "FAILED: rack_added did not return expected results"
+        success_msg: "PASSED: rack_added succeeded, racks={{ rack_add1.racks | length }}"
+      when: rack_add1 is defined
+
+    # ── TEST RACK_ADD-2 (idempotency) ────────────────────────────────────
+    - name: "[TEST RACK_ADD-2] Re-run rack_added with same count (idempotency)"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        rack_type: "{{ existing_rack_type_id }}"
+        rack_count: 3
+        state: rack_added
+        auth_token: "{{ auth.token }}"
+      register: rack_add2
+      when: existing_rack_type_id is defined and existing_rack_type_id | length > 0
+
+    - name: "[TEST RACK_ADD-2] Verify idempotency"
+      ansible.builtin.assert:
+        that:
+          - rack_add2 is defined
+          - rack_add2 is success
+          - not rack_add2.changed
+        fail_msg: "FAILED: rack_added is not idempotent (changed=true on second run)"
+        success_msg: "PASSED: rack_added is idempotent (changed=false)"
+      when: rack_add2 is defined
+
+    # ── TEST RACK_ADD-3 (lower count — still idempotent) ─────────────────
+    - name: "[TEST RACK_ADD-3] rack_added with smaller count than current — no change"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        rack_type: "{{ existing_rack_type_id }}"
+        rack_count: 1
+        state: rack_added
+        auth_token: "{{ auth.token }}"
+      register: rack_add3
+      when: existing_rack_type_id is defined and existing_rack_type_id | length > 0
+
+    - name: "[TEST RACK_ADD-3] Verify no change when below current count"
+      ansible.builtin.assert:
+        that:
+          - rack_add3 is defined
+          - rack_add3 is success
+          - not rack_add3.changed
+        fail_msg: "FAILED: rack_added should not change when count <= existing"
+        success_msg: "PASSED: rack_added with lower count is idempotent"
+      when: rack_add3 is defined
+
+    # ── TEST RACK_TYPE-1 (invalid type → fail with helpful message) ───────
+    - name: "[TEST RACK_TYPE-1] rack_added with non-existent type name"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        rack_type: "nonexistent-rack-type-xyz"
+        rack_count: 1
+        state: rack_added
+        auth_token: "{{ auth.token }}"
+      register: rack_bad_type
+      ignore_errors: true
+
+    - name: "[TEST RACK_TYPE-1] Verify failure with helpful error"
+      ansible.builtin.assert:
+        that:
+          - rack_bad_type is failed
+          - "'nonexistent-rack-type-xyz' in rack_bad_type.msg"
+        fail_msg: "FAILED: Invalid rack type should fail with name in msg"
+        success_msg: "PASSED: Invalid rack type correctly rejected"
+
+    # ── TEST RACK_DEL-1 — delete a rack by its graph node ID ─────────────
+    - name: "[TEST RACK_DEL-1] Refresh rack list to pick a node ID to delete"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        query: "node('rack', name='rack')"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: rack_qe_before_del
+
+    - name: "[TEST RACK_DEL-1] Save the last rack's node_id for deletion"
+      ansible.builtin.set_fact:
+        rack_to_delete: "{{ rack_qe_before_del.nodes[-1].rack.id }}"
+      when:
+        - rack_qe_before_del is success
+        - rack_qe_before_del.nodes | length > 0
+
+    - name: "[TEST RACK_DEL-1] Delete the rack by node ID"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        rack_id: "{{ rack_to_delete }}"
+        state: rack_deleted
+        auth_token: "{{ auth.token }}"
+      register: rack_del1
+      when: rack_to_delete is defined
+
+    - name: "[TEST RACK_DEL-1] Verify rack was deleted"
+      ansible.builtin.assert:
+        that:
+          - rack_del1 is defined
+          - rack_del1 is success
+          - rack_del1.changed
+          - rack_del1.racks_deleted | length == 1
+          - rack_to_delete in rack_del1.racks_deleted
+        fail_msg: "FAILED: rack_deleted did not report the deleted rack"
+        success_msg: "PASSED: rack_deleted succeeded, deleted={{ rack_del1.racks_deleted }}"
+      when: rack_del1 is defined
+
+    # ── TEST RACK_DEL-2 (idempotency — same ID, already gone) ────────────
+    - name: "[TEST RACK_DEL-2] Delete same rack again (idempotency)"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        rack_id: "{{ rack_to_delete }}"
+        state: rack_deleted
+        auth_token: "{{ auth.token }}"
+      register: rack_del2
+      when: rack_to_delete is defined
+
+    - name: "[TEST RACK_DEL-2] Verify idempotency"
+      ansible.builtin.assert:
+        that:
+          - rack_del2 is defined
+          - rack_del2 is success
+          - not rack_del2.changed
+        fail_msg: "FAILED: rack_deleted is not idempotent (changed=true for already-deleted rack)"
+        success_msg: "PASSED: rack_deleted is idempotent (changed=false for already-deleted rack)"
+      when: rack_del2 is defined
+
+    # ── Cleanup ───────────────────────────────────────────────────────────
+    - name: "[RACK CLEANUP] Delete rack test blueprint"
+      juniper.apstra.blueprint:
+        id: "{{ bp_rack.id }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
     - name: Logout of Apstra
       juniper.apstra.authenticate:
         logout: true


### PR DESCRIPTION
- Add resolve_rack_type_id() to name_resolution.py for name/ID resolution
- Add _handle_rack_added() with idempotency (desired count vs current)
- Add _handle_rack_deleted() with idempotency (skip already-deleted racks)
- New params: rack_type (str), rack_count (int, default 1)
- Update argspec, DOCUMENTATION, EXAMPLES, and RETURN
- Add rack management integration tests to tests/blueprint.yml