### PR TITLE
Add interface management features including speed, tags, and LAG mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,7 @@ install: build
 	test-system_agents \
 	test-os_upgrade \
 	test-upgrade_group \
+	test-interface \
 	test-interface_map \
 	test-fabric_settings \
 	test-ztp_device \
@@ -222,6 +223,9 @@ test-os_upgrade: install
 
 test-upgrade_group: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/upgrade_group.yml
+
+test-interface: install
+	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/interface.yml
 
 test-interface_map: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/interface_map.yml

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_interface.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_interface.py
@@ -41,7 +41,6 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes imp
     node_needs_update,
 )
 
-
 # ──────────────────────────────────────────────────────────────────
 #  Admin state mapping
 # ──────────────────────────────────────────────────────────────────
@@ -196,12 +195,95 @@ def set_operation_state(client_factory, blueprint_id, iface_id, admin_state):
 # ──────────────────────────────────────────────────────────────────
 
 
-def set_interface_tags(client_factory, blueprint_id, iface_id, tags, state="present"):
-    """Set or remove tags on an interface node.
+def _get_current_tags(client_factory, blueprint_id, iface_id):
+    """Return the list of tag labels currently applied to an interface node.
 
-    Tags are stored as a list of string labels on the interface node's
-    ``tags`` field.  The API accepts any string labels; they do not need
-    to be pre-created as blueprint tag objects.
+    Uses the blueprint graph to read ``type='tag'`` relationships that
+    point TO the interface node.  This is the authoritative source — the
+    Apstra UI also reads these graph relationships (not the node's ``tags``
+    property field).
+
+    Returns:
+        list[str]: Tag labels currently applied.
+    """
+    qe = f"node(id='{iface_id}', name='n').in_('tag').node('tag', name='t')"
+    items = run_qe_query(client_factory, blueprint_id, qe)
+    return [item["t"]["label"] for item in items if item.get("t")]
+
+
+def _ensure_tags_exist(client_factory, blueprint_id, tag_labels):
+    """Ensure tag objects exist in the blueprint for all given labels.
+
+    ``POST /blueprints/{id}/tagging`` silently ignores labels that do not
+    have a corresponding tag object.  This helper creates any missing tag
+    objects via ``POST /blueprints/{id}/tags`` before the tagging API is
+    called.
+
+    Args:
+        tag_labels: Iterable of tag label strings to ensure exist.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/nodes?node_type=tag")
+    if resp.status_code not in (200, 201, 202):
+        raise RuntimeError(
+            f"GET /nodes?node_type=tag failed: HTTP {resp.status_code} — {resp.text}"
+        )
+    existing_labels = {
+        v["label"] for v in resp.json().get("nodes", {}).values() if v.get("label")
+    }
+    for label in tag_labels:
+        if label not in existing_labels:
+            cr = base.raw_request(
+                f"/blueprints/{blueprint_id}/tags",
+                method="POST",
+                data={"label": label},
+            )
+            if cr.status_code not in (200, 201, 202):
+                raise RuntimeError(
+                    f"Failed to create tag '{label}': "
+                    f"HTTP {cr.status_code} — {cr.text}"
+                )
+
+
+def _call_tagging_api(client_factory, blueprint_id, iface_id, add, remove):
+    """POST /blueprints/{id}/tagging to add/remove tag graph relationships.
+
+    This is the only correct way to tag nodes so that the Apstra UI shows
+    the tags.  Patching the node's ``tags`` property directly does NOT
+    create the required ``type='tag'`` graph edges.
+
+    Args:
+        add: List of tag label strings to add (pass ``[]`` or ``None`` to skip).
+        remove: List of tag label strings to remove (pass ``[]`` or ``None`` to skip).
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/tagging",
+        method="POST",
+        data={
+            "nodes": [iface_id],
+            "add": add if add else None,
+            "remove": remove if remove else None,
+        },
+    )
+    if resp.status_code not in (200, 201, 202):
+        raise RuntimeError(
+            f"POST /tagging failed: HTTP {resp.status_code} — {resp.text}"
+        )
+
+
+def set_interface_tags(client_factory, blueprint_id, iface_id, tags, state="present"):
+    """Set or remove tags on an interface node using the Apstra tagging API.
+
+    Uses ``POST /blueprints/{id}/tagging`` which creates proper ``type='tag'``
+    graph relationships between the tag node and the interface node.  This is
+    the only approach that makes tags visible in the Apstra UI.
+
+    Tag objects are automatically created in the blueprint when ``state=present``
+    if they do not yet exist.
+
+    Idempotent: reads current tag relationships before deciding whether to
+    call the tagging API.
 
     Args:
         client_factory: An ``ApstraClientFactory`` instance.
@@ -215,63 +297,47 @@ def set_interface_tags(client_factory, blueprint_id, iface_id, tags, state="pres
     Returns:
         dict: ``{changed, node_id, tags, msg}``
     """
-    current = get_node(client_factory, blueprint_id, iface_id)
-    if current is None:
-        raise ValueError(
-            f"Interface node '{iface_id}' not found in blueprint '{blueprint_id}'"
-        )
-
-    current_tags = list(current.get("tags") or [])
+    current_tags = _get_current_tags(client_factory, blueprint_id, iface_id)
     desired_tags = list(tags or [])
 
     if state == "present":
-        new_tags = list(current_tags)
-        added = []
-        for tag in desired_tags:
-            if tag not in new_tags:
-                new_tags.append(tag)
-                added.append(tag)
-        if not added:
+        to_add = [t for t in desired_tags if t not in current_tags]
+        if not to_add:
             return dict(
                 changed=False,
                 node_id=iface_id,
                 tags=current_tags,
                 msg="Tags already present (no change)",
             )
-        patch_node(
-            client_factory,
-            blueprint_id,
-            iface_id,
-            {"tags": new_tags},
+        _ensure_tags_exist(client_factory, blueprint_id, to_add)
+        _call_tagging_api(
+            client_factory, blueprint_id, iface_id, add=to_add, remove=None
         )
         return dict(
             changed=True,
             node_id=iface_id,
-            tags=new_tags,
-            msg=f"Added tags: {added}",
+            tags=list(set(current_tags + to_add)),
+            msg=f"Added tags: {to_add}",
         )
 
     elif state == "absent":
-        new_tags = [t for t in current_tags if t not in desired_tags]
-        removed = [t for t in current_tags if t in desired_tags]
-        if not removed:
+        to_remove = [t for t in desired_tags if t in current_tags]
+        if not to_remove:
             return dict(
                 changed=False,
                 node_id=iface_id,
                 tags=current_tags,
                 msg="Tags already absent (no change)",
             )
-        patch_node(
-            client_factory,
-            blueprint_id,
-            iface_id,
-            {"tags": new_tags if new_tags else None},
+        _call_tagging_api(
+            client_factory, blueprint_id, iface_id, add=None, remove=to_remove
         )
+        new_tags = [t for t in current_tags if t not in to_remove]
         return dict(
             changed=True,
             node_id=iface_id,
             tags=new_tags,
-            msg=f"Removed tags: {removed}",
+            msg=f"Removed tags: {to_remove}",
         )
 
     else:

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_interface.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_interface.py
@@ -1,0 +1,347 @@
+# Copyright (c) 2024, Juniper Networks
+# BSD 3-Clause License
+
+"""Blueprint interface utilities.
+
+Provides reusable helpers for reading and patching blueprint interface
+nodes via the Apstra REST API.
+
+Primary use cases:
+  - Set ``operation_state`` (admin up/down) on interface nodes
+  - Set ``tags`` on interface nodes (ethernet or port_channel)
+  - Set ``lag_mode`` and ``port_channel_id`` on port_channel interface nodes
+  - Resolve interface nodes via graph queries
+
+These helpers are consumed by:
+  - modules/blueprint.py  (state=interface_updated, interface_tagged, lag_updated)
+
+Usage inside a module::
+
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_interface import (
+        find_interface_node,
+        set_operation_state,
+        set_interface_tags,
+        set_lag_mode,
+    )
+
+    iface = find_interface_node(client_factory, bp_id, "leaf1", "ge-0/0/0")
+    result = set_operation_state(client_factory, bp_id, iface["id"], "down")
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+    run_qe_query,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes import (
+    get_node,
+    patch_node,
+    node_needs_update,
+)
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Admin state mapping
+# ──────────────────────────────────────────────────────────────────
+
+# Apstra stores the interface admin-down state as "admin_down" in the
+# operation_state field.  The module param uses "up" / "down" as values.
+_ADMIN_STATE_MAP = {
+    "up": "up",
+    "down": "admin_down",
+}
+
+# Valid lag_mode values accepted by Apstra
+_VALID_LAG_MODES = frozenset({"lacp_active", "lacp_passive", "static_lag", "none"})
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Interface node discovery
+# ──────────────────────────────────────────────────────────────────
+
+
+def find_interface_node(client_factory, blueprint_id, system_label, if_name):
+    """Resolve a system label + interface name to an interface node dict.
+
+    Runs a blueprint graph query (QE) to find the interface node
+    ``if_name`` that is hosted on the system with label ``system_label``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        system_label: The blueprint node label for the switch/system
+            (e.g. ``"leaf1"``).
+        if_name: The interface name (e.g. ``"ge-0/0/0"`` or ``"ae4"``).
+
+    Returns:
+        dict or None: The interface node properties dict (including ``id``),
+        or *None* if not found.
+    """
+    qe = (
+        f"node('system', label='{system_label}', name='sys')"
+        f".out('hosted_interfaces')"
+        f".node('interface', if_name='{if_name}', name='iface')"
+    )
+    items = run_qe_query(client_factory, blueprint_id, qe)
+    if not items:
+        return None
+    return items[0].get("iface")
+
+
+def find_interface_nodes_by_type(
+    client_factory, blueprint_id, system_label, if_type=None
+):
+    """Find all interface nodes hosted on a system, optionally filtered by if_type.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        system_label: The blueprint node label for the switch/system.
+        if_type: Optional interface type filter, e.g. ``"ethernet"``
+            or ``"port_channel"``.  When *None*, all interfaces are returned.
+
+    Returns:
+        list[dict]: List of interface node property dicts.
+    """
+    if if_type:
+        qe = (
+            f"node('system', label='{system_label}', name='sys')"
+            f".out('hosted_interfaces')"
+            f".node('interface', if_type='{if_type}', name='iface')"
+        )
+    else:
+        qe = (
+            f"node('system', label='{system_label}', name='sys')"
+            f".out('hosted_interfaces')"
+            f".node('interface', name='iface')"
+        )
+    items = run_qe_query(client_factory, blueprint_id, qe)
+    return [item["iface"] for item in items if item.get("iface")]
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Feature 2: Interface admin state (shut / no-shut)
+# ──────────────────────────────────────────────────────────────────
+
+
+def set_operation_state(client_factory, blueprint_id, iface_id, admin_state):
+    """Set the admin state of an interface node (shut / no-shut).
+
+    In Apstra v6, the interface node ``operation_state`` field is used to
+    configure interface shutdown:
+
+    * ``"up"`` — interface is administratively enabled (no-shut).
+    * ``"admin_down"`` — interface is administratively disabled (shut).
+
+    This function accepts the human-readable ``admin_state`` values
+    ``"up"`` and ``"down"`` and maps them to the Apstra ``operation_state``
+    values before patching.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        iface_id: The interface node UUID in the blueprint.
+        admin_state: ``"up"`` (no-shut) or ``"down"`` (shut).
+
+    Returns:
+        dict: ``{changed, node_id, admin_state, operation_state, msg}``
+    """
+    desired_op_state = _ADMIN_STATE_MAP.get(admin_state)
+    if desired_op_state is None:
+        raise ValueError(
+            f"Invalid admin_state '{admin_state}'. "
+            f"Valid values: {sorted(_ADMIN_STATE_MAP.keys())}"
+        )
+
+    current = get_node(client_factory, blueprint_id, iface_id)
+    if current is None:
+        raise ValueError(
+            f"Interface node '{iface_id}' not found in blueprint '{blueprint_id}'"
+        )
+
+    current_op_state = current.get("operation_state")
+
+    # Treat None (unset) as "up" for idempotency purposes
+    effective_current = current_op_state if current_op_state is not None else "up"
+
+    if effective_current == desired_op_state:
+        return dict(
+            changed=False,
+            node_id=iface_id,
+            admin_state=admin_state,
+            operation_state=current_op_state,
+            msg=f"Interface already in admin_state='{admin_state}' (no change)",
+        )
+
+    patch_node(
+        client_factory,
+        blueprint_id,
+        iface_id,
+        {"operation_state": desired_op_state},
+    )
+
+    return dict(
+        changed=True,
+        node_id=iface_id,
+        admin_state=admin_state,
+        operation_state=desired_op_state,
+        msg=f"Interface admin_state set to '{admin_state}' (operation_state='{desired_op_state}')",
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Feature 3: Interface tags
+# ──────────────────────────────────────────────────────────────────
+
+
+def set_interface_tags(client_factory, blueprint_id, iface_id, tags, state="present"):
+    """Set or remove tags on an interface node.
+
+    Tags are stored as a list of string labels on the interface node's
+    ``tags`` field.  The API accepts any string labels; they do not need
+    to be pre-created as blueprint tag objects.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        iface_id: The interface node UUID.
+        tags: List of tag label strings to add (``state=present``) or
+            remove (``state=absent``).
+        state: ``"present"`` (ensure tags exist) or ``"absent"``
+            (ensure tags are removed).
+
+    Returns:
+        dict: ``{changed, node_id, tags, msg}``
+    """
+    current = get_node(client_factory, blueprint_id, iface_id)
+    if current is None:
+        raise ValueError(
+            f"Interface node '{iface_id}' not found in blueprint '{blueprint_id}'"
+        )
+
+    current_tags = list(current.get("tags") or [])
+    desired_tags = list(tags or [])
+
+    if state == "present":
+        new_tags = list(current_tags)
+        added = []
+        for tag in desired_tags:
+            if tag not in new_tags:
+                new_tags.append(tag)
+                added.append(tag)
+        if not added:
+            return dict(
+                changed=False,
+                node_id=iface_id,
+                tags=current_tags,
+                msg="Tags already present (no change)",
+            )
+        patch_node(
+            client_factory,
+            blueprint_id,
+            iface_id,
+            {"tags": new_tags},
+        )
+        return dict(
+            changed=True,
+            node_id=iface_id,
+            tags=new_tags,
+            msg=f"Added tags: {added}",
+        )
+
+    elif state == "absent":
+        new_tags = [t for t in current_tags if t not in desired_tags]
+        removed = [t for t in current_tags if t in desired_tags]
+        if not removed:
+            return dict(
+                changed=False,
+                node_id=iface_id,
+                tags=current_tags,
+                msg="Tags already absent (no change)",
+            )
+        patch_node(
+            client_factory,
+            blueprint_id,
+            iface_id,
+            {"tags": new_tags if new_tags else None},
+        )
+        return dict(
+            changed=True,
+            node_id=iface_id,
+            tags=new_tags,
+            msg=f"Removed tags: {removed}",
+        )
+
+    else:
+        raise ValueError(f"Invalid state '{state}'. Use 'present' or 'absent'.")
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Feature 4: LAG mode
+# ──────────────────────────────────────────────────────────────────
+
+
+def set_lag_mode(
+    client_factory, blueprint_id, iface_id, lag_mode, port_channel_id=None
+):
+    """Set the LAG mode (and optionally port_channel_id) on an interface node.
+
+    This is used for port_channel (LAG) interfaces on managed switches.
+    Valid ``lag_mode`` values: ``lacp_active``, ``lacp_passive``,
+    ``static_lag``, ``none``.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        iface_id: The interface node UUID (should be a ``port_channel``
+            interface for this operation to be meaningful).
+        lag_mode: The desired LAG mode string.
+        port_channel_id: Optional integer port channel / AE interface
+            number (e.g. ``4`` for ``ae4``).  When *None*, the existing
+            ``port_channel_id`` is left unchanged.
+
+    Returns:
+        dict: ``{changed, node_id, lag_mode, port_channel_id, msg}``
+    """
+    if lag_mode not in _VALID_LAG_MODES:
+        raise ValueError(
+            f"Invalid lag_mode '{lag_mode}'. "
+            f"Valid values: {sorted(_VALID_LAG_MODES)}"
+        )
+
+    current = get_node(client_factory, blueprint_id, iface_id)
+    if current is None:
+        raise ValueError(
+            f"Interface node '{iface_id}' not found in blueprint '{blueprint_id}'"
+        )
+
+    desired = {"lag_mode": lag_mode}
+    if port_channel_id is not None:
+        desired["port_channel_id"] = port_channel_id
+
+    changes = node_needs_update(current, desired)
+    if not changes:
+        return dict(
+            changed=False,
+            node_id=iface_id,
+            lag_mode=current.get("lag_mode"),
+            port_channel_id=current.get("port_channel_id"),
+            msg="LAG configuration already up to date (no change)",
+        )
+
+    patch_node(client_factory, blueprint_id, iface_id, changes)
+    final_lag_mode = changes.get("lag_mode", current.get("lag_mode"))
+    final_pc_id = changes.get("port_channel_id", current.get("port_channel_id"))
+
+    return dict(
+        changed=True,
+        node_id=iface_id,
+        lag_mode=final_lag_mode,
+        port_channel_id=final_pc_id,
+        msg=(
+            f"LAG configuration updated: "
+            + ", ".join(f"{k}={v}" for k, v in changes.items())
+        ),
+    )

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_interface_speed.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_interface_speed.py
@@ -1,0 +1,583 @@
+# Copyright (c) 2024, Juniper Networks
+# BSD 3-Clause License
+
+"""Blueprint interface speed utilities.
+
+Provides reusable helpers for changing physical link speed on blueprint
+interfaces via the official Apstra WebUI APIs:
+
+    PUT /blueprints/{id}/set-physical-link-speed
+    PUT /blueprints/{id}/set-switch-system-link-speed
+
+Link resolution strategy
+------------------------
+The ``link_id`` required by those endpoints is obtained by a single
+blueprint graph query (QE):
+
+    node('system', label=<system>)
+      .out('hosted_interfaces')
+      .node('interface', if_name=<if_name>, name='ifc')
+      .out()
+      .node('link', name='lnk')
+
+This returns the link node directly, including its ``id`` (used as
+``link_id``), ``speed`` (current speed string, e.g. ``"100G"``), and
+``role`` (used to select the correct API endpoint).
+
+This approach works for both normal design IMs and blueprint-local IMs
+(Apstra v6.1.1): for connected ports the blueprint graph interface node
+always carries ``if_name``; ``if_name=None`` only appears on
+disconnected/unassigned ports which have no link attached anyway.
+
+Idempotency
+-----------
+The current link speed is read from the link node ``speed`` field in the
+same QE call.  If it already matches the desired speed the module returns
+``changed=False`` without calling any write API.
+
+Speed validation
+----------------
+Before applying the change, the desired speed is checked against the
+device-profile transforms for the interface.  An informative error lists
+the supported speeds when the requested value is invalid.
+
+These helpers are consumed by:
+    - modules/interface_map.py  (state=speed_updated)
+
+Usage inside a module::
+
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_interface_speed import (
+        SpeedChangeError,
+        normalize_speed,
+        change_interface_speed,
+        get_im_for_system,
+        get_effective_im_node,
+        im_has_transform_id,
+    )
+
+    try:
+        result = change_interface_speed(
+            client_factory, blueprint_id, system_name,
+            if_name, desired_value, desired_unit, speed_str, check_mode,
+        )
+    except SpeedChangeError as exc:
+        module.fail_json(msg=str(exc))
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import json
+import re
+
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+    run_qe_query,
+)
+
+# ──────────────────────────────────────────────────────────────────
+#  Constants
+# ──────────────────────────────────────────────────────────────────
+
+# Link roles that require set-switch-system-link-speed instead of
+# set-physical-link-speed (mirrors Apstra WebUI logic).
+_SWITCH_SYS_ROLES = frozenset({"to_generic", "access_l3", "to_access_switch"})
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Public exception
+# ──────────────────────────────────────────────────────────────────
+
+
+class SpeedChangeError(Exception):
+    """Raised when a speed change cannot be completed.
+
+    Callers should catch this and call ``module.fail_json(msg=str(exc))``.
+    """
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Speed string helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+def normalize_speed(speed_str):
+    """Normalize a speed string to a ``(value, unit)`` tuple.
+
+    Accepted formats: ``"25G"``, ``"25g"``, ``"100G"``, ``"10G"``, etc.
+
+    Args:
+        speed_str (str): Raw speed string from playbook params.
+
+    Returns:
+        tuple[int, str]: ``(value, unit)`` e.g. ``(100, "G")``.
+
+    Raises:
+        SpeedChangeError: If the string cannot be parsed.
+    """
+    m = re.match(r"^(\d+)\s*([A-Za-z]+)$", speed_str.strip())
+    if not m:
+        raise SpeedChangeError(
+            "Cannot parse speed '{0}'. "
+            "Expected format like '25G', '100G', '10G'.".format(speed_str)
+        )
+    return int(m.group(1)), m.group(2).upper()
+
+
+# ──────────────────────────────────────────────────────────────────
+#  SDK client helper
+# ──────────────────────────────────────────────────────────────────
+
+
+def _get_client(client_factory):
+    """Return the l3clos SDK client."""
+    return client_factory.get_l3clos_client()
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Link resolution via blueprint graph QE
+# ──────────────────────────────────────────────────────────────────
+
+
+def find_link_via_qe(client_factory, blueprint_id, system_name, if_name):
+    """Find the physical link for a system interface using a graph QE.
+
+    Traverses the blueprint graph::
+
+        node('system', label=<system_name>)
+          .out('hosted_interfaces')
+          .node('interface', if_name=<if_name>, name='ifc')
+          .out()
+          .node('link', name='lnk')
+
+    The ``link`` node carries ``id`` (the ``link_id`` needed by
+    ``set-physical-link-speed``), ``speed`` (current speed string, e.g.
+    ``"100G"``), and ``role`` (used to select the correct write API).
+
+    This works for both normal design IMs and blueprint-local IMs
+    (Apstra v6.1.1).  For connected ports the blueprint graph interface
+    node always carries ``if_name``; ``if_name=None`` only appears on
+    disconnected/unassigned ports which have no link attached anyway.
+
+    Args:
+        client_factory: ``ApstraClientFactory``.
+        blueprint_id (str): Blueprint UUID.
+        system_name (str): Blueprint node label, e.g. ``"DC2-Leaf1"``.
+        if_name (str): Interface name, e.g. ``"et-0/0/49"``.
+
+    Returns:
+        tuple: ``(link_id, current_speed, link_role)`` or
+        ``(None, None, None)`` when not found.
+    """
+    qe_str = (
+        "node('system', label='{0}', name='sys')"
+        ".out('hosted_interfaces')"
+        ".node('interface', if_name='{1}', name='ifc')"
+        ".out()"
+        ".node('link', name='lnk')"
+    ).format(system_name, if_name)
+
+    items = run_qe_query(client_factory, blueprint_id, qe_str)
+    if not items:
+        return None, None, None
+
+    lnk = items[0].get("lnk", {})
+    return lnk.get("id"), lnk.get("speed", ""), lnk.get("role", "")
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Interface map assignment helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+def get_im_assignments(client_factory, blueprint_id):
+    """Return the IM assignment dict ``{system_node_id: im_id}``."""
+    client = _get_client(client_factory)
+    result = client.blueprints[blueprint_id].get_im_assignments()
+    if result and isinstance(result, dict):
+        return result
+    return {}
+
+
+def get_im_for_system(client_factory, blueprint_id, system_name):
+    """Resolve ``system_name`` to ``(system_node_id, im_id)``.
+
+    Args:
+        client_factory: ``ApstraClientFactory``.
+        blueprint_id (str): Blueprint UUID.
+        system_name (str): Blueprint node label of the target switch.
+
+    Returns:
+        tuple[str, str]: ``(system_node_id, im_id)``.
+
+    Raises:
+        SpeedChangeError: If the system or IM assignment is not found.
+    """
+    qe = "node('system', label='{0}', name='sys')".format(system_name)
+    items = run_qe_query(client_factory, blueprint_id, qe)
+    if not items:
+        raise SpeedChangeError(
+            "System '{0}' not found in blueprint '{1}'".format(
+                system_name, blueprint_id
+            )
+        )
+    system_node_id = items[0].get("sys", {}).get("id")
+    if not system_node_id:
+        raise SpeedChangeError(
+            "System '{0}' graph node has no id".format(system_name)
+        )
+
+    assignments = get_im_assignments(client_factory, blueprint_id)
+    im_id = assignments.get(system_node_id)
+    if not im_id:
+        raise SpeedChangeError(
+            "No interface map assignment found for system '{0}'. "
+            "Assign an interface map before changing port speed.".format(system_name)
+        )
+
+    return system_node_id, im_id
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Interface map node helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+def get_blueprint_im_node(client_factory, blueprint_id, im_id):
+    """Fetch the blueprint-level IM node.
+
+    Returns:
+        dict: The IM node properties dict, or empty dict if not found.
+    """
+    client = _get_client(client_factory)
+    try:
+        return (
+            client.request(
+                "/blueprints/{0}/nodes/{1}".format(blueprint_id, im_id),
+                method="GET",
+            )
+            or {}
+        )
+    except Exception:
+        return {}
+
+
+def get_design_im(client_factory, im_id):
+    """Fetch a design-level interface map by ID.
+
+    Returns:
+        dict: The design IM dict, or empty dict if not found.
+    """
+    client = _get_client(client_factory)
+    try:
+        return (
+            client.request(
+                "/design/interface-maps/{0}".format(im_id), method="GET"
+            )
+            or {}
+        )
+    except Exception:
+        return {}
+
+
+def get_effective_im_node(client_factory, blueprint_id, im_id):
+    """Return the best available IM node — blueprint-local first, then design.
+
+    Blueprint-local IMs (``_v2`` variants) only exist at the blueprint level;
+    they are not in the design catalog.
+
+    Returns:
+        dict: IM node properties dict (non-empty).
+
+    Raises:
+        SpeedChangeError: If neither source returns a usable IM.
+    """
+    im_node = get_blueprint_im_node(client_factory, blueprint_id, im_id)
+    if im_node and im_node.get("interfaces"):
+        return im_node
+    im_node = get_design_im(client_factory, im_id)
+    if im_node and im_node.get("interfaces"):
+        return im_node
+    raise SpeedChangeError(
+        "Interface map '{0}' not found at blueprint or design level.".format(im_id)
+    )
+
+
+def find_im_entry(im_node, if_name):
+    """Find the IM interface entry for ``if_name``.
+
+    Args:
+        im_node (dict): IM node from ``get_effective_im_node``.
+        if_name (str): Interface name, e.g. ``"et-0/0/49"``.
+
+    Returns:
+        dict or None: The matching entry dict, or ``None`` if not found.
+    """
+    for entry in im_node.get("interfaces", []):
+        entry_name = entry.get("name") or entry.get("if_name")
+        if entry_name == if_name:
+            return entry
+    return None
+
+
+def parse_im_entry_setting(entry):
+    """Parse ``entry['setting']['param']`` JSON into a plain dict.
+
+    The IM setting is stored as a JSON string inside ``setting.param``.
+
+    Returns:
+        dict: Parsed setting dict.  Returns empty dict on parse failure.
+    """
+    raw = entry.get("setting", {}).get("param", "{}")
+    try:
+        return json.loads(raw)
+    except (ValueError, TypeError):
+        return {}
+
+
+def im_has_transform_id(im_node, if_name, transform_id):
+    """Return ``True`` if ``if_name`` already uses ``transform_id``.
+
+    Checks ``mapping[1]`` of the matching interface entry.
+    """
+    for entry in im_node.get("interfaces", []):
+        entry_name = entry.get("name") or entry.get("if_name")
+        if entry_name == if_name:
+            mapping = entry.get("mapping", [])
+            current_tid = mapping[1] if len(mapping) > 1 else None
+            return current_tid == transform_id
+    return False
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Device profile helpers (speed validation)
+# ──────────────────────────────────────────────────────────────────
+
+
+def get_dp_ports(client_factory, blueprint_id, im_id):
+    """Return device profile port list for the given blueprint IM.
+
+    Traverses ``interface_map → device_profile`` in the blueprint graph.
+
+    Returns:
+        list: Port list with transformations, or empty list.
+    """
+    qe = (
+        "node('interface_map', id='{0}', name='im')"
+        ".out().node('device_profile', name='dp')".format(im_id)
+    )
+    items = run_qe_query(client_factory, blueprint_id, qe)
+    if not items:
+        return []
+    return items[0].get("dp", {}).get("ports", [])
+
+
+def find_transform_for_speed(dp_ports, if_name, desired_value, desired_unit):
+    """Return the ``transformation_id`` for a non-breakout port at given speed.
+
+    Searches each port's transformations for one whose sole interface matches
+    ``if_name`` and speed ``(desired_value, desired_unit)``.
+
+    Returns:
+        int or None: Matching transformation_id, or ``None`` if not found.
+    """
+    for port in dp_ports:
+        for transform in port.get("transformations", []):
+            ifaces = transform.get("interfaces", [])
+            if len(ifaces) == 1 and ifaces[0].get("name") == if_name:
+                sp = ifaces[0].get("speed", {})
+                if (
+                    sp.get("value") == desired_value
+                    and sp.get("unit", "").upper() == desired_unit
+                ):
+                    return transform["transformation_id"]
+    return None
+
+
+def list_speeds_for_iface(dp_ports, if_name):
+    """Return unique non-breakout speeds available for ``if_name``.
+
+    Returns:
+        list[str]: E.g. ``["40G", "100G"]``.
+    """
+    seen = []
+    for port in dp_ports:
+        for transform in port.get("transformations", []):
+            ifaces = transform.get("interfaces", [])
+            if len(ifaces) == 1 and ifaces[0].get("name") == if_name:
+                sp = ifaces[0].get("speed", {})
+                label = "{0}{1}".format(sp.get("value", "?"), sp.get("unit", ""))
+                if label not in seen:
+                    seen.append(label)
+    return seen
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Speed apply operation
+# ──────────────────────────────────────────────────────────────────
+
+
+def set_link_speed(client_factory, blueprint_id, link_id, link_role, value, unit):
+    """Call ``set-physical-link-speed`` or ``set-switch-system-link-speed``.
+
+    Selects the correct Apstra API based on ``link_role``:
+
+    - Access / generic-system links (``to_generic``, ``access_l3``,
+      ``to_access_switch``) → ``set-switch-system-link-speed``
+    - All other roles (e.g. ``spine_leaf``) → ``set-physical-link-speed``
+
+    Apstra updates both the topology link speed and the interface map
+    automatically.
+
+    Args:
+        client_factory: ``ApstraClientFactory``.
+        blueprint_id (str): Blueprint UUID.
+        link_id (str): The link UUID from the blueprint graph.
+        link_role (str): Link role string, e.g. ``"spine_leaf"``.
+        value (int): Speed value, e.g. ``100``.
+        unit (str): Speed unit, e.g. ``"G"``.
+
+    Raises:
+        SpeedChangeError: On API failure.
+    """
+    client = _get_client(client_factory)
+    payload = {
+        "links": [
+            {
+                "link_id": link_id,
+                "speed": {"unit": unit, "value": value},
+            }
+        ]
+    }
+    try:
+        if link_role in _SWITCH_SYS_ROLES:
+            client.blueprints[blueprint_id].set_switch_system_link_speed(payload)
+        else:
+            client.blueprints[blueprint_id].set_physical_link_speed(payload)
+    except Exception as exc:
+        raise SpeedChangeError(
+            "Speed change API failed for link '{0}': {1}".format(link_id, exc)
+        )
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Top-level speed change orchestrator
+# ──────────────────────────────────────────────────────────────────
+
+
+def change_interface_speed(
+    client_factory,
+    blueprint_id,
+    system_name,
+    if_name,
+    desired_value,
+    desired_unit,
+    speed_str,
+    check_mode=False,
+):
+    """Change the speed of a physical interface.
+
+    Workflow:
+
+    1. **Link resolution** — Run a blueprint graph QE to find the link
+       attached to ``(system_name, if_name)``.  The QE returns ``link_id``,
+       current ``link_speed``, and ``link_role`` in a single call.
+
+    2. **Speed validation** — Check the desired speed against the
+       device-profile transforms.  Fail early with a list of supported
+       speeds if the value is invalid.
+
+    3. **Idempotency** — Compare ``link.speed`` against ``desired_speed``.
+       Return ``changed=False`` without any write API call if already set.
+
+    4. **Apply** — Call ``set-physical-link-speed`` or
+       ``set-switch-system-link-speed`` based on ``link_role``.
+
+    Args:
+        client_factory: ``ApstraClientFactory``.
+        blueprint_id (str): Blueprint UUID.
+        system_name (str): Blueprint node label of the target switch.
+        if_name (str): Interface name, e.g. ``"et-0/0/49"``.
+        desired_value (int): Speed value from ``normalize_speed``.
+        desired_unit (str): Speed unit from ``normalize_speed``.
+        speed_str (str): Original speed string for messages, e.g. ``"100G"``.
+        check_mode (bool): When ``True``, report the intended change
+            without applying it.
+
+    Returns:
+        dict: Ansible result with ``changed`` (bool) and ``msg`` (str).
+
+    Raises:
+        SpeedChangeError: On any unrecoverable error.  The caller should
+            call ``module.fail_json(msg=str(exc))``.
+    """
+    desired_speed_str = "{0}{1}".format(desired_value, desired_unit)
+
+    # ── Step 1: find the link via blueprint graph QE ───────────────────────
+    link_id, current_speed, link_role = find_link_via_qe(
+        client_factory, blueprint_id, system_name, if_name
+    )
+
+    if not link_id:
+        raise SpeedChangeError(
+            "Interface '{0}' not found on system '{1}' in the blueprint "
+            "graph (no connected link).  Verify the interface name and that "
+            "a physical link is present in the cabling map.".format(
+                if_name, system_name
+            )
+        )
+
+    # ── Step 2: validate desired speed against device profile ──────────────
+    _system_node_id, im_id = get_im_for_system(
+        client_factory, blueprint_id, system_name
+    )
+    dp_ports = get_dp_ports(client_factory, blueprint_id, im_id)
+    transform_id = find_transform_for_speed(
+        dp_ports, if_name, desired_value, desired_unit
+    )
+    if transform_id is None:
+        available = list_speeds_for_iface(dp_ports, if_name)
+        raise SpeedChangeError(
+            "Speed {0} is not valid for interface '{1}' on '{2}'.  "
+            "Available speeds: {3}".format(
+                speed_str, if_name, system_name,
+                available or "none found in device profile",
+            )
+        )
+
+    # ── Step 3: idempotency check ──────────────────────────────────────────
+    if current_speed == desired_speed_str:
+        return dict(
+            changed=False,
+            msg=(
+                "Link speed of '{0}' on '{1}' is already {2} "
+                "(no change)".format(if_name, system_name, speed_str)
+            ),
+        )
+
+    # ── Step 4: check_mode ─────────────────────────────────────────────────
+    if check_mode:
+        return dict(
+            changed=True,
+            msg=(
+                "Would change link speed of '{0}' on '{1}' "
+                "from {2} to {3}".format(
+                    if_name, system_name, current_speed, speed_str
+                )
+            ),
+        )
+
+    # ── Step 5: apply via set-physical-link-speed ──────────────────────────
+    set_link_speed(
+        client_factory, blueprint_id, link_id, link_role, desired_value, desired_unit
+    )
+
+    return dict(
+        changed=True,
+        msg=(
+            "Link speed of '{0}' on '{1}' changed "
+            "from {2} to {3}".format(
+                if_name, system_name, current_speed, speed_str
+            )
+        ),
+    )

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -143,10 +143,74 @@ options:
       - C(rack_added) adds racks of a rack type using either C(rack_count)
         (desired total, idempotent) or C(racks_to_add) (delta, non-idempotent).
       - C(rack_deleted) deletes rack(s) by C(rack_id) / C(node_id).
+      - C(interface_updated) sets the admin state (shut/no-shut) of a
+        blueprint interface node. Use C(system_name), C(interface_name),
+        and C(admin_state) to target and configure the interface.
+      - C(interface_tagged) adds or removes tags on a blueprint interface
+        node. Use C(system_name), C(interface_name), C(tags), and
+        C(state=interface_tagged) with C(tag_state=present/absent).
+      - C(lag_updated) sets C(lag_mode) (and optionally C(port_channel_id))
+        on a port-channel interface of a managed switch.
     required: false
     type: str
-    choices: ["present", "committed", "absent", "queried", "node_updated", "rack_added", "rack_deleted"]
+    choices: ["present", "committed", "absent", "queried", "node_updated", "rack_added", "rack_deleted", "interface_updated", "interface_tagged", "lag_updated"]
     default: "present"
+  system_name:
+    description:
+      - The label of the system (switch/server) node in the blueprint.
+      - Required when C(state=interface_updated), C(state=interface_tagged),
+        or C(state=lag_updated).
+    type: str
+    required: false
+  interface_name:
+    description:
+      - The interface name on the system (e.g. C(ge-0/0/0), C(ae4)).
+      - Required when C(state=interface_updated), C(state=interface_tagged),
+        or C(state=lag_updated).
+    type: str
+    required: false
+  admin_state:
+    description:
+      - Desired administrative state of the interface.
+      - C(up) enables the interface (no-shut).
+      - C(down) disables the interface (shut).
+      - Only used when C(state=interface_updated).
+    type: str
+    required: false
+    choices: ["up", "down"]
+  tags:
+    description:
+      - List of tag labels to add or remove on the interface node.
+      - Only used when C(state=interface_tagged).
+      - Combined with C(tag_state) to determine whether tags are added
+        or removed.
+    type: list
+    elements: str
+    required: false
+  tag_state:
+    description:
+      - Whether to add or remove the specified C(tags) on the interface.
+      - C(present) ensures the tags exist on the interface node.
+      - C(absent) removes the tags from the interface node.
+      - Only used when C(state=interface_tagged).
+    type: str
+    required: false
+    choices: ["present", "absent"]
+    default: "present"
+  lag_mode:
+    description:
+      - LAG mode to set on a port-channel interface of a managed switch.
+      - Only used when C(state=lag_updated).
+    type: str
+    required: false
+    choices: ["lacp_active", "lacp_passive", "static_lag", "none"]
+  port_channel_id:
+    description:
+      - Optional port-channel interface number (e.g. C(4) for C(ae4)).
+      - When set, updates the C(port_channel_id) field alongside C(lag_mode).
+      - Only used when C(state=lag_updated).
+    type: int
+    required: false
   query:
     description:
       - A raw QE query string.
@@ -514,6 +578,62 @@ EXAMPLES = """
       blueprint: "{{ blueprint_id }}"
     rack_id: "da_rack_001"
     state: rack_deleted
+
+# Shut down an interface (admin down)
+- name: Shut leaf1 ge-0/0/0 interface
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    system_name: "leaf1"
+    interface_name: "ge-0/0/0"
+    admin_state: "down"
+    state: interface_updated
+  register: intf_shut
+
+# Re-enable a shut-down interface
+- name: No-shut leaf1 ge-0/0/0
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    system_name: "leaf1"
+    interface_name: "ge-0/0/0"
+    admin_state: "up"
+    state: interface_updated
+
+# Add tags to an ethernet interface
+- name: Tag leaf1 ge-0/0/0 as 'uplink' and 'production'
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    system_name: "leaf1"
+    interface_name: "ge-0/0/0"
+    tags:
+      - uplink
+      - production
+    tag_state: present
+    state: interface_tagged
+
+# Remove a tag from an interface
+- name: Remove 'uplink' tag from leaf1 ge-0/0/0
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    system_name: "leaf1"
+    interface_name: "ge-0/0/0"
+    tags:
+      - uplink
+    tag_state: absent
+    state: interface_tagged
+
+# Change LAG mode on a port-channel interface
+- name: Set leaf1 ae4 to lacp_passive
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    system_name: "leaf1"
+    interface_name: "ae4"
+    lag_mode: "lacp_passive"
+    state: lag_updated
 """
 
 RETURN = """
@@ -627,6 +747,42 @@ racks_deleted:
     returned: when racks were deleted
     type: list
     elements: str
+interface_node_id:
+    description:
+        - The blueprint node UUID of the interface that was targeted.
+        - Returned by C(state=interface_updated), C(state=interface_tagged),
+          and C(state=lag_updated).
+    returned: when using interface management states
+    type: str
+admin_state:
+    description:
+        - The resolved admin state of the interface after the operation.
+        - Returned by C(state=interface_updated).
+    returned: when using interface_updated
+    type: str
+    sample: "down"
+operation_state:
+    description:
+        - The raw Apstra C(operation_state) value on the interface node.
+        - C("up") means enabled; C("admin_down") means shut.
+        - Returned by C(state=interface_updated).
+    returned: when using interface_updated
+    type: str
+    sample: "admin_down"
+interface_tags:
+    description:
+        - Final list of tag labels on the interface node after the operation.
+        - Returned by C(state=interface_tagged).
+    returned: when using interface_tagged
+    type: list
+    elements: str
+lag_mode:
+    description:
+        - The final C(lag_mode) on the interface node after the operation.
+        - Returned by C(state=lag_updated).
+    returned: when using lag_updated
+    type: str
+    sample: "lacp_passive"
 """
 
 from time import sleep
@@ -663,6 +819,12 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolut
     resolve_graph_node_id,
     resolve_rack_node_id,
     resolve_system_node_id,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_interface import (
+    find_interface_node,
+    set_operation_state,
+    set_interface_tags,
+    set_lag_mode,
 )
 
 
@@ -874,6 +1036,90 @@ def _handle_rack_deleted(module, client_factory, blueprint_id):
         racks_deleted=deleted,
         msg=f"Deleted {n} rack(s) from blueprint",
     )
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Interface management handlers (Features 2, 3, 4)
+# ──────────────────────────────────────────────────────────────────
+
+
+def _resolve_interface_node_id(module, client_factory, blueprint_id):
+    """Resolve system_name + interface_name to an interface node UUID.
+
+    Fails the module with a descriptive error if either the system or the
+    interface cannot be found.
+
+    Returns:
+        str: The interface node UUID.
+    """
+    system_name = module.params.get("system_name")
+    interface_name = module.params.get("interface_name")
+
+    if not system_name:
+        module.fail_json(msg="system_name is required for interface management states")
+    if not interface_name:
+        module.fail_json(
+            msg="interface_name is required for interface management states"
+        )
+
+    iface = find_interface_node(
+        client_factory, blueprint_id, system_name, interface_name
+    )
+    if iface is None:
+        module.fail_json(
+            msg=(
+                f"Interface '{interface_name}' not found on system '{system_name}' "
+                f"in blueprint '{blueprint_id}'"
+            )
+        )
+    return iface["id"]
+
+
+def _handle_interface_updated(module, client_factory, blueprint_id):
+    """Handle state=interface_updated — set admin state (shut/no-shut)."""
+    admin_state = module.params.get("admin_state")
+    if not admin_state:
+        module.fail_json(msg="admin_state is required when state=interface_updated")
+
+    iface_id = _resolve_interface_node_id(module, client_factory, blueprint_id)
+    result = set_operation_state(client_factory, blueprint_id, iface_id, admin_state)
+    result["interface_node_id"] = result.pop("node_id", iface_id)
+    return result
+
+
+def _handle_interface_tagged(module, client_factory, blueprint_id):
+    """Handle state=interface_tagged — add or remove tags on an interface."""
+    tags = module.params.get("tags")
+    if not tags:
+        module.fail_json(msg="tags is required when state=interface_tagged")
+
+    tag_state = module.params.get("tag_state") or "present"
+    iface_id = _resolve_interface_node_id(module, client_factory, blueprint_id)
+    result = set_interface_tags(
+        client_factory, blueprint_id, iface_id, tags, state=tag_state
+    )
+    result["interface_node_id"] = result.pop("node_id", iface_id)
+    result["interface_tags"] = result.pop("tags", [])
+    return result
+
+
+def _handle_lag_updated(module, client_factory, blueprint_id):
+    """Handle state=lag_updated — set lag_mode on a port-channel interface."""
+    lag_mode = module.params.get("lag_mode")
+    if not lag_mode:
+        module.fail_json(msg="lag_mode is required when state=lag_updated")
+
+    port_channel_id = module.params.get("port_channel_id")
+    iface_id = _resolve_interface_node_id(module, client_factory, blueprint_id)
+    result = set_lag_mode(
+        client_factory,
+        blueprint_id,
+        iface_id,
+        lag_mode,
+        port_channel_id=port_channel_id,
+    )
+    result["interface_node_id"] = result.pop("node_id", iface_id)
+    return result
 
 
 # ──────────────────────────────────────────────────────────────────
@@ -1261,6 +1507,9 @@ def main():
                 "node_updated",
                 "rack_added",
                 "rack_deleted",
+                "interface_updated",
+                "interface_tagged",
+                "lag_updated",
             ],
             default="present",
         ),
@@ -1302,6 +1551,20 @@ def main():
         hostname=dict(type="str", required=False),
         node_label=dict(type="str", required=False, aliases=["rack_label"]),
         node_properties=dict(type="dict", required=False),
+        # Interface management params (state=interface_updated / interface_tagged / lag_updated)
+        system_name=dict(type="str", required=False),
+        interface_name=dict(type="str", required=False),
+        admin_state=dict(type="str", required=False, choices=["up", "down"]),
+        tags=dict(type="list", elements="str", required=False),
+        tag_state=dict(
+            type="str", required=False, choices=["present", "absent"], default="present"
+        ),
+        lag_mode=dict(
+            type="str",
+            required=False,
+            choices=["lacp_active", "lacp_passive", "static_lag", "none"],
+        ),
+        port_channel_id=dict(type="int", required=False),
     )
     client_module_args = apstra_client_module_args()
     module_args = client_module_args | blueprint_module_args
@@ -1366,6 +1629,34 @@ def main():
             if not blueprint_id:
                 module.fail_json(msg="id.blueprint is required when state=rack_deleted")
             result = _handle_rack_deleted(module, client_factory, blueprint_id)
+            module.exit_json(**result)
+            return
+
+        # ── state=interface_updated ───────────────────────────────
+        if state == "interface_updated":
+            if not blueprint_id:
+                module.fail_json(
+                    msg="id.blueprint is required when state=interface_updated"
+                )
+            result = _handle_interface_updated(module, client_factory, blueprint_id)
+            module.exit_json(**result)
+            return
+
+        # ── state=interface_tagged ────────────────────────────────
+        if state == "interface_tagged":
+            if not blueprint_id:
+                module.fail_json(
+                    msg="id.blueprint is required when state=interface_tagged"
+                )
+            result = _handle_interface_tagged(module, client_factory, blueprint_id)
+            module.exit_json(**result)
+            return
+
+        # ── state=lag_updated ─────────────────────────────────────
+        if state == "lag_updated":
+            if not blueprint_id:
+                module.fail_json(msg="id.blueprint is required when state=lag_updated")
+            result = _handle_lag_updated(module, client_factory, blueprint_id)
             module.exit_json(**result)
             return
 

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -1162,12 +1162,62 @@ def _handle_interface_updated(module, client_factory, blueprint_id):
 
 
 def _handle_interface_tagged(module, client_factory, blueprint_id):
-    """Handle state=interface_tagged — add or remove tags on an interface."""
+    """Handle state=interface_tagged — add or remove tags on an interface.
+
+    Supports both single-interface mode (system_name + interface_name + tags)
+    and batch mode (interfaces list of {system_name, interface_name} with
+    shared tags / tag_state params).
+    """
     tags = module.params.get("tags")
     if not tags:
         module.fail_json(msg="tags is required when state=interface_tagged")
 
     tag_state = module.params.get("tag_state") or "present"
+    interfaces = module.params.get("interfaces")
+
+    if interfaces:
+        # Batch mode: apply same tags/tag_state to all listed interfaces
+        results = []
+        any_changed = False
+        for entry in interfaces:
+            sys_name = entry.get("system_name")
+            if_name = entry.get("interface_name")
+            if not sys_name or not if_name:
+                module.fail_json(
+                    msg=(
+                        "Each entry in 'interfaces' must have "
+                        "system_name and interface_name"
+                    )
+                )
+            iface = find_interface_node(client_factory, blueprint_id, sys_name, if_name)
+            if iface is None:
+                module.fail_json(
+                    msg=(
+                        f"Interface '{if_name}' not found on system '{sys_name}' "
+                        f"in blueprint '{blueprint_id}'"
+                    )
+                )
+            r = set_interface_tags(
+                client_factory, blueprint_id, iface["id"], tags, state=tag_state
+            )
+            if r.get("changed"):
+                any_changed = True
+            results.append(
+                {
+                    "system_name": sys_name,
+                    "interface_name": if_name,
+                    "changed": r.get("changed", False),
+                    "interface_node_id": r.get("node_id", iface["id"]),
+                    "interface_tags": r.get("tags", []),
+                }
+            )
+        return dict(
+            changed=any_changed,
+            interfaces=results,
+            msg=f"Tagged {len(interfaces)} interface(s)",
+        )
+
+    # Single-interface mode (backward compatible)
     iface_id = _resolve_interface_node_id(module, client_factory, blueprint_id)
     result = set_interface_tags(
         client_factory, blueprint_id, iface_id, tags, state=tag_state

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -174,10 +174,19 @@ options:
       - Desired administrative state of the interface.
       - C(up) enables the interface (no-shut).
       - C(down) disables the interface (shut).
-      - Only used when C(state=interface_updated).
+      - Only used when C(state=interface_updated) in single-interface mode.
     type: str
     required: false
     choices: ["up", "down"]
+  interfaces:
+    description:
+      - List of interfaces to update in a single task (batch mode).
+      - Only used when C(state=interface_updated).
+      - Each entry must have C(system_name), C(interface_name), and C(admin_state).
+      - Mutually exclusive with single-interface mode (C(system_name) / C(interface_name) / C(admin_state)).
+    type: list
+    elements: dict
+    required: false
   tags:
     description:
       - List of tag labels to add or remove on the interface node.
@@ -600,6 +609,23 @@ EXAMPLES = """
     admin_state: "up"
     state: interface_updated
 
+# Batch shut multiple interfaces in one task
+- name: Shut down multiple spine interfaces
+  juniper.apstra.blueprint:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    interfaces:
+      - system_name: "spine1"
+        interface_name: "et-0/0/0"
+        admin_state: "down"
+      - system_name: "spine1"
+        interface_name: "et-0/0/1"
+        admin_state: "down"
+      - system_name: "spine2"
+        interface_name: "et-0/0/0"
+        admin_state: "up"
+    state: interface_updated
+
 # Add tags to an ethernet interface
 - name: Tag leaf1 ge-0/0/0 as 'uplink' and 'production'
   juniper.apstra.blueprint:
@@ -826,7 +852,6 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_interface
     set_interface_tags,
     set_lag_mode,
 )
-
 
 # ──────────────────────────────────────────────────────────────────
 #  Rack management helpers
@@ -1076,11 +1101,60 @@ def _resolve_interface_node_id(module, client_factory, blueprint_id):
 
 
 def _handle_interface_updated(module, client_factory, blueprint_id):
-    """Handle state=interface_updated — set admin state (shut/no-shut)."""
+    """Handle state=interface_updated — set admin state (shut/no-shut).
+
+    Supports both single-interface mode (system_name + interface_name + admin_state)
+    and batch mode (interfaces list of {system_name, interface_name, admin_state}).
+    """
+    interfaces = module.params.get("interfaces")
+
+    if interfaces:
+        # Batch mode: iterate over the list
+        results = []
+        any_changed = False
+        for entry in interfaces:
+            sys_name = entry.get("system_name")
+            if_name = entry.get("interface_name")
+            adm_state = entry.get("admin_state")
+            if not sys_name or not if_name or not adm_state:
+                module.fail_json(
+                    msg=(
+                        "Each entry in 'interfaces' must have "
+                        "system_name, interface_name, and admin_state"
+                    )
+                )
+            iface = find_interface_node(client_factory, blueprint_id, sys_name, if_name)
+            if iface is None:
+                module.fail_json(
+                    msg=(
+                        f"Interface '{if_name}' not found on system '{sys_name}' "
+                        f"in blueprint '{blueprint_id}'"
+                    )
+                )
+            r = set_operation_state(
+                client_factory, blueprint_id, iface["id"], adm_state
+            )
+            if r.get("changed"):
+                any_changed = True
+            results.append(
+                {
+                    "system_name": sys_name,
+                    "interface_name": if_name,
+                    "admin_state": adm_state,
+                    "changed": r.get("changed", False),
+                    "interface_node_id": r.get("node_id", iface["id"]),
+                }
+            )
+        return dict(
+            changed=any_changed,
+            interfaces=results,
+            msg=f"Updated {len(interfaces)} interface(s)",
+        )
+
+    # Single-interface mode (backward compatible)
     admin_state = module.params.get("admin_state")
     if not admin_state:
         module.fail_json(msg="admin_state is required when state=interface_updated")
-
     iface_id = _resolve_interface_node_id(module, client_factory, blueprint_id)
     result = set_operation_state(client_factory, blueprint_id, iface_id, admin_state)
     result["interface_node_id"] = result.pop("node_id", iface_id)
@@ -1555,6 +1629,7 @@ def main():
         system_name=dict(type="str", required=False),
         interface_name=dict(type="str", required=False),
         admin_state=dict(type="str", required=False, choices=["up", "down"]),
+        interfaces=dict(type="list", elements="dict", required=False),
         tags=dict(type="list", elements="str", required=False),
         tag_state=dict(
             type="str", required=False, choices=["present", "absent"], default="present"

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -654,7 +654,21 @@ def _speed_via_interface_transformation(
             }
         ]
     }
-    client.blueprints[blueprint_id].interface_transformation.put(payload)
+    try:
+        client.blueprints[blueprint_id].interface_transformation.put(payload)
+    except Exception as exc:
+        exc_str = str(exc)
+        if "not synced with config" in exc_str.lower() or "staging" in exc_str.lower():
+            module.fail_json(
+                msg=(
+                    f"Cannot change speed of '{if_name}' on '{system_name}': "
+                    f"the blueprint has staged changes that have not been deployed. "
+                    f"Deploy (commit) the blueprint in the Apstra UI or API to sync "
+                    f"staging with the device config, then retry this playbook. "
+                    f"Apstra error: {exc_str}"
+                )
+            )
+        module.fail_json(msg=f"interface-transformation failed: {exc_str}")
 
     return dict(
         changed=True,

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -82,6 +82,8 @@ options:
         from the design interface-maps catalog.
       - Values may be C(null) or an empty string to clear an assignment.
       - "Example: C(assignments: {spine1: Juniper_vJunos-switch_vJunos})"
+      - When C(state=speed_updated): must contain C(system_name),
+        C(interface_name), and either C(speed) or C(transform_id).
     type: dict
     required: true
   state:
@@ -90,9 +92,14 @@ options:
       - C(present) assigns the specified interface maps to nodes.
       - C(absent) clears the interface map assignments for the
         specified nodes (sets them to null).
+      - C(speed_updated) changes the speed or transform of a specific
+        interface on a system by selecting the appropriate interface map
+        from the design catalog. Requires C(body.system_name),
+        C(body.interface_name), and either C(body.speed) (e.g. C("25G"),
+        C("100G")) or C(body.transform_id) (integer).
     type: str
     required: false
-    choices: ["present", "absent"]
+    choices: ["present", "absent", "speed_updated"]
     default: "present"
 """
 
@@ -141,6 +148,28 @@ EXAMPLES = """
       assignments:
         "{{ node_id }}": null
     state: absent
+
+# ── Change interface speed / breakout ────────────────────────────
+
+- name: Set spine1 et-0/0/0 to 100G
+  juniper.apstra.interface_map:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    body:
+      system_name: "spine1"
+      interface_name: "et-0/0/0"
+      speed: "100G"
+    state: speed_updated
+
+- name: Set leaf1 xe-0/0/0 breakout to 4x25G (by transform_id)
+  juniper.apstra.interface_map:
+    id:
+      blueprint: "{{ blueprint_id }}"
+    body:
+      system_name: "leaf1"
+      interface_name: "xe-0/0/0"
+      transform_id: 2
+    state: speed_updated
 """
 
 RETURN = """
@@ -159,6 +188,14 @@ msg:
   description: The output message that the module generates.
   type: str
   returned: always
+interface_map_id:
+  description: The interface map ID assigned after a C(speed_updated) operation.
+  type: str
+  returned: when state is speed_updated and changed is true
+system_node_id:
+  description: The blueprint node UUID of the system targeted by C(speed_updated).
+  type: str
+  returned: when state is speed_updated
 """
 
 import traceback
@@ -395,6 +432,257 @@ def _handle_absent(module, client_factory):
 
 
 # ──────────────────────────────────────────────────────────────────
+#  Feature 1: Interface speed / breakout (state=speed_updated)
+# ──────────────────────────────────────────────────────────────────
+
+
+def _get_design_im_list(client_factory):
+    """Return all design interface maps as a list of dicts.
+
+    Uses ``GET /design/interface-maps`` via the l3clos SDK client.
+
+    Returns:
+        list[dict]: Each dict has at least ``id``, ``label``,
+        ``device_profile_id``, ``logical_device_id``, and ``interfaces``.
+    """
+    client = _get_l3clos_client(client_factory)
+    result = client.request("/design/interface-maps", method="GET")
+    return (result or {}).get("items", [])
+
+
+def _get_design_im_detail(client_factory, im_id):
+    """Return full details of a design interface map by ID."""
+    client = _get_l3clos_client(client_factory)
+    return client.request(f"/design/interface-maps/{im_id}", method="GET") or {}
+
+
+def _normalize_speed(speed_str):
+    """Normalize a speed string like '25G', '25g', '25000M' to uppercase 'G' form.
+
+    Accepted input formats:
+      - ``"25G"`` / ``"25g"`` → ``"25G"``
+      - ``"100G"`` → ``"100G"``
+      - Integer ``{value}`` and unit ``G`` / ``T`` etc.
+
+    Returns:
+        tuple[int, str]: (value, unit) — e.g. (25, "G").
+    """
+    import re
+
+    m = re.match(r"^(\d+)\s*([A-Za-z]+)$", speed_str.strip())
+    if not m:
+        raise ValueError(
+            f"Cannot parse speed '{speed_str}'. "
+            f"Expected format like '25G', '100G', '10G'."
+        )
+    return int(m.group(1)), m.group(2).upper()
+
+
+def _im_has_speed_for_interface(im_detail, if_name, desired_value, desired_unit):
+    """Return True if this interface map has the desired speed for ``if_name``.
+
+    Checks the ``interfaces`` list in the IM for an entry whose ``name``
+    matches ``if_name`` and whose ``speed.value``/``speed.unit`` match
+    the desired speed.
+    """
+    for intf in im_detail.get("interfaces", []):
+        intf_name = intf.get("name") or intf.get("if_name")
+        if intf_name == if_name:
+            spd = intf.get("speed") or {}
+            if isinstance(spd, dict):
+                if (
+                    spd.get("value") == desired_value
+                    and spd.get("unit", "").upper() == desired_unit
+                ):
+                    return True
+    return False
+
+
+def _im_has_transform_id(im_detail, if_name, transform_id):
+    """Return True if this IM has the specified transform_id for ``if_name``.
+
+    In newer device profiles, transforms are listed per interface.
+    Falls back to True if the IM's logical_device matches and the
+    transform_id would be valid.
+    """
+    for intf in im_detail.get("interfaces", []):
+        intf_name = intf.get("name") or intf.get("if_name")
+        if intf_name == if_name:
+            transforms = intf.get("transforms", [])
+            for t in transforms:
+                if t.get("id") == transform_id:
+                    return True
+    return False
+
+
+def _resolve_system_node_for_im(client_factory, blueprint_id, system_name):
+    """Resolve a system node label to its blueprint node UUID.
+
+    Returns:
+        str or None: The node UUID, or None if not found.
+    """
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+        run_qe_query,
+    )
+
+    qe = f"node('system', label='{system_name}', name='sys')"
+    items = run_qe_query(client_factory, blueprint_id, qe)
+    if not items:
+        return None
+    return items[0].get("sys", {}).get("id")
+
+
+def _handle_speed_updated(module, client_factory):
+    """Handle state=speed_updated — change speed/breakout via interface map.
+
+    Finds an interface map in the design catalog that satisfies the desired
+    speed (or transform_id) for the specified interface on a system, then
+    re-assigns that interface map to the system node.
+
+    Idempotency: reads the current assignment and checks whether it
+    already provides the desired speed for the interface.  No change is
+    made if it does.
+    """
+    p = module.params
+    id_param = p["id"] or {}
+    blueprint_id = id_param.get("blueprint")
+    if blueprint_id:
+        blueprint_id = client_factory.resolve_blueprint_id(blueprint_id)
+        id_param["blueprint"] = blueprint_id
+    body = p["body"] or {}
+
+    system_name = body.get("system_name")
+    if_name = body.get("interface_name")
+    speed = body.get("speed")
+    transform_id = body.get("transform_id")
+
+    if not system_name:
+        module.fail_json(msg="body.system_name is required when state=speed_updated")
+    if not if_name:
+        module.fail_json(msg="body.interface_name is required when state=speed_updated")
+    if speed is None and transform_id is None:
+        module.fail_json(
+            msg="Either body.speed or body.transform_id is required when state=speed_updated"
+        )
+    if speed is not None and transform_id is not None:
+        module.fail_json(msg="body.speed and body.transform_id are mutually exclusive")
+
+    # Parse speed if provided
+    desired_value = None
+    desired_unit = None
+    if speed is not None:
+        try:
+            desired_value, desired_unit = _normalize_speed(str(speed))
+        except ValueError as exc:
+            module.fail_json(msg=str(exc))
+
+    # Resolve system node in the blueprint
+    node_id = _resolve_system_node_for_im(client_factory, blueprint_id, system_name)
+    if not node_id:
+        module.fail_json(
+            msg=f"System '{system_name}' not found in blueprint '{blueprint_id}'"
+        )
+
+    # Get current interface map assignment for this node
+    current = _get_assignments(client_factory, blueprint_id)
+    current_im_id = current.get(node_id)
+
+    # Get all design interface maps
+    all_ims = _get_design_im_list(client_factory)
+
+    # If a current IM is assigned, check idempotency first
+    if current_im_id:
+        current_im_detail = _get_design_im_detail(client_factory, current_im_id)
+        if speed is not None:
+            if _im_has_speed_for_interface(
+                current_im_detail, if_name, desired_value, desired_unit
+            ):
+                return dict(
+                    changed=False,
+                    assignments=current,
+                    system_node_id=node_id,
+                    msg=(
+                        f"Interface '{if_name}' on '{system_name}' already uses "
+                        f"interface map '{current_im_id}' which provides "
+                        f"speed {speed} (no change)"
+                    ),
+                )
+        else:
+            if _im_has_transform_id(current_im_detail, if_name, transform_id):
+                return dict(
+                    changed=False,
+                    assignments=current,
+                    system_node_id=node_id,
+                    msg=(
+                        f"Interface '{if_name}' on '{system_name}' already uses "
+                        f"interface map '{current_im_id}' with transform_id={transform_id} "
+                        f"(no change)"
+                    ),
+                )
+
+    # Determine the device profile of the current IM (or system) to restrict search
+    current_dp_id = None
+    if current_im_id:
+        current_im_detail = _get_design_im_detail(client_factory, current_im_id)
+        current_dp_id = current_im_detail.get("device_profile_id")
+
+    # Find best-matching IM in the catalog
+    candidate_im_id = None
+    for im in all_ims:
+        # If we know the device profile, only look at IMs for the same device
+        if current_dp_id and im.get("device_profile_id") != current_dp_id:
+            continue
+
+        im_id = im.get("id")
+        if not im_id:
+            continue
+
+        # Fetch full IM detail to check interfaces
+        im_detail = _get_design_im_detail(client_factory, im_id)
+        if speed is not None:
+            if _im_has_speed_for_interface(
+                im_detail, if_name, desired_value, desired_unit
+            ):
+                candidate_im_id = im_id
+                break
+        else:
+            if _im_has_transform_id(im_detail, if_name, transform_id):
+                candidate_im_id = im_id
+                break
+
+    if not candidate_im_id:
+        criteria = (
+            f"speed={speed}" if speed is not None else f"transform_id={transform_id}"
+        )
+        device_info = f" for device profile '{current_dp_id}'" if current_dp_id else ""
+        module.fail_json(
+            msg=(
+                f"No interface map found{device_info} that provides "
+                f"{criteria} for interface '{if_name}'"
+            )
+        )
+
+    # Apply the new assignment
+    _patch_assignments(client_factory, blueprint_id, {node_id: candidate_im_id})
+    final = dict(current)
+    final[node_id] = candidate_im_id
+
+    criteria_msg = (
+        f"speed={speed}" if speed is not None else f"transform_id={transform_id}"
+    )
+    return dict(
+        changed=True,
+        assignments=final,
+        system_node_id=node_id,
+        interface_map_id=candidate_im_id,
+        msg=(
+            f"Interface '{if_name}' on '{system_name}': assigned interface map "
+            f"'{candidate_im_id}' ({criteria_msg})"
+        ),
+    )
+
+
+# ──────────────────────────────────────────────────────────────────
 #  Module entry point
 # ──────────────────────────────────────────────────────────────────
 
@@ -406,7 +694,7 @@ def main():
         state=dict(
             type="str",
             required=False,
-            choices=["present", "absent"],
+            choices=["present", "absent", "speed_updated"],
             default="present",
         ),
     )
@@ -425,6 +713,8 @@ def main():
             result = _handle_present(module, client_factory)
         elif state == "absent":
             result = _handle_absent(module, client_factory)
+        elif state == "speed_updated":
+            result = _handle_speed_updated(module, client_factory)
 
     except Exception as e:
         tb = traceback.format_exc()

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -206,7 +206,6 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client impor
     ApstraClientFactory,
 )
 
-
 # ──────────────────────────────────────────────────────────────────
 #  SDK helpers
 # ──────────────────────────────────────────────────────────────────
@@ -590,9 +589,17 @@ def _handle_speed_updated(module, client_factory):
     # Get all design interface maps
     all_ims = _get_design_im_list(client_factory)
 
-    # If a current IM is assigned, check idempotency first
+    # Fetch current IM detail once (used for idempotency + DP/LD filtering)
+    current_im_detail = None
+    current_dp_id = None
+    current_ld_id = None
     if current_im_id:
         current_im_detail = _get_design_im_detail(client_factory, current_im_id)
+        current_dp_id = current_im_detail.get("device_profile_id")
+        current_ld_id = current_im_detail.get("logical_device_id")
+
+    # If a current IM is assigned, check idempotency first
+    if current_im_detail:
         if speed is not None:
             if _im_has_speed_for_interface(
                 current_im_detail, if_name, desired_value, desired_unit
@@ -620,17 +627,16 @@ def _handle_speed_updated(module, client_factory):
                     ),
                 )
 
-    # Determine the device profile of the current IM (or system) to restrict search
-    current_dp_id = None
-    if current_im_id:
-        current_im_detail = _get_design_im_detail(client_factory, current_im_id)
-        current_dp_id = current_im_detail.get("device_profile_id")
-
     # Find best-matching IM in the catalog
+    # Restrict to same device_profile_id AND logical_device_id so the assignment
+    # is accepted by Apstra (cross-LD assignments are rejected with HTTP 422).
     candidate_im_id = None
     for im in all_ims:
-        # If we know the device profile, only look at IMs for the same device
+        # Only look at IMs for the same device profile
         if current_dp_id and im.get("device_profile_id") != current_dp_id:
+            continue
+        # Apstra requires the new IM to use the same logical_device_id
+        if current_ld_id and im.get("logical_device_id") != current_ld_id:
             continue
 
         im_id = im.get("id")
@@ -655,10 +661,12 @@ def _handle_speed_updated(module, client_factory):
             f"speed={speed}" if speed is not None else f"transform_id={transform_id}"
         )
         device_info = f" for device profile '{current_dp_id}'" if current_dp_id else ""
+        ld_info = f" with logical_device_id '{current_ld_id}'" if current_ld_id else ""
         module.fail_json(
             msg=(
-                f"No interface map found{device_info} that provides "
-                f"{criteria} for interface '{if_name}'"
+                f"No interface map found{device_info}{ld_info} that provides "
+                f"{criteria} for interface '{if_name}'. "
+                f"Create a compatible interface map in the design catalog first."
             )
         )
 

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -455,6 +455,34 @@ def _get_design_im_detail(client_factory, im_id):
     return client.request(f"/design/interface-maps/{im_id}", method="GET") or {}
 
 
+def _get_blueprint_im_node(client_factory, blueprint_id, im_id):
+    """Return a blueprint node of type interface_map by ID.
+
+    Used as fallback when the IM exists only at the blueprint level
+    (e.g. Apstra-created ``_v2`` variants) and is not in the design catalog.
+    Returns an empty dict if not found.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/nodes/{im_id}")
+    if resp.status_code == 200:
+        return resp.json()
+    return {}
+
+
+def _get_blueprint_im_nodes(client_factory, blueprint_id):
+    """Return all interface_map nodes defined at the blueprint level.
+
+    Uses ``GET /blueprints/{id}/nodes?node_type=interface_map``.
+    Returns a list of node dicts (may include both design-derived and
+    blueprint-local IMs such as Apstra-created ``_v2`` speed variants).
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/nodes?node_type=interface_map")
+    if resp.status_code == 200:
+        return list(resp.json().get("nodes", {}).values())
+    return []
+
+
 def _normalize_speed(speed_str):
     """Normalize a speed string like '25G', '25g', '25000M' to uppercase 'G' form.
 
@@ -589,12 +617,20 @@ def _handle_speed_updated(module, client_factory):
     # Get all design interface maps
     all_ims = _get_design_im_list(client_factory)
 
-    # Fetch current IM detail once (used for idempotency + DP/LD filtering)
+    # Fetch current IM detail once (used for idempotency + DP/LD filtering).
+    # Try design catalog first; fall back to blueprint node lookup for
+    # blueprint-local IMs (e.g. Apstra-created ``_v2`` speed variants that
+    # exist only in the blueprint, not in ``/design/interface-maps``).
     current_im_detail = None
     current_dp_id = None
     current_ld_id = None
     if current_im_id:
         current_im_detail = _get_design_im_detail(client_factory, current_im_id)
+        if not current_im_detail:
+            # Not in design catalog — look it up as a blueprint node
+            current_im_detail = _get_blueprint_im_node(
+                client_factory, blueprint_id, current_im_id
+            )
         current_dp_id = current_im_detail.get("device_profile_id")
         current_ld_id = current_im_detail.get("logical_device_id")
 
@@ -655,6 +691,32 @@ def _handle_speed_updated(module, client_factory):
             if _im_has_transform_id(im_detail, if_name, transform_id):
                 candidate_im_id = im_id
                 break
+
+    if not candidate_im_id:
+        # Design catalog has no suitable IM.  Also search blueprint-level IM
+        # nodes — Apstra creates blueprint-local variants (e.g. ``_v2``) when
+        # the WebUI changes a port speed.  These nodes share the same device
+        # profile but may carry a different (derived) logical_device_id, so
+        # we only filter by device_profile_id here.
+        bp_ims = _get_blueprint_im_nodes(client_factory, blueprint_id)
+        for im in bp_ims:
+            im_id = im.get("id")
+            if not im_id or im_id == current_im_id:
+                continue
+            if current_dp_id and im.get("device_profile_id") != current_dp_id:
+                continue
+            # Note: skip the LD filter for blueprint IMs — their LD may differ
+            # from the design LD while still being a valid speed variant.
+            if speed is not None:
+                if _im_has_speed_for_interface(
+                    im, if_name, desired_value, desired_unit
+                ):
+                    candidate_im_id = im_id
+                    break
+            else:
+                if _im_has_transform_id(im, if_name, transform_id):
+                    candidate_im_id = im_id
+                    break
 
     if not candidate_im_id:
         criteria = (

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -198,6 +198,7 @@ system_node_id:
   returned: when state is speed_updated
 """
 
+import json
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
@@ -566,6 +567,69 @@ def _list_speeds_for_iface(dp_ports, if_name):
     return seen
 
 
+def _fix_im_setting_via_patch(
+    module,
+    client,
+    blueprint_id,
+    im_id,
+    system_name,
+    if_name,
+    desired_value,
+    desired_unit,
+    speed,
+    im_node,
+):
+    """Change IM interface speed via a direct node PATCH with allow_unsafe=true.
+
+    Called when ``interface-transformation`` returns a "staging not synced"
+    error.  Updating ``setting.global.speed`` on the IM node directly
+    bypasses that check, and Apstra automatically selects the matching
+    transform_id (``mapping[1]``) for the new speed.
+    """
+    im_ifaces = im_node.get("interfaces", [])
+    target_entry = next(
+        (i for i in im_ifaces if (i.get("name") or i.get("if_name")) == if_name),
+        None,
+    )
+    if target_entry is None:
+        module.fail_json(
+            msg=(
+                f"Interface '{if_name}' not found in interface map for "
+                f"'{system_name}'"
+            )
+        )
+
+    speed_str = f"{desired_value}{desired_unit.lower()}"
+    updated_ifaces = []
+    for ifc in im_ifaces:
+        if (ifc.get("name") or ifc.get("if_name")) == if_name:
+            ni = dict(ifc)
+            try:
+                setting = json.loads(ni.get("setting", {}).get("param", "{}"))
+            except (ValueError, TypeError):
+                setting = {}
+            setting.setdefault("global", {})["speed"] = speed_str
+            setting.setdefault("interface", {"speed": ""})
+            ni["setting"] = {"param": json.dumps(setting)}
+            updated_ifaces.append(ni)
+        else:
+            updated_ifaces.append(ifc)
+
+    client.request(
+        f"/blueprints/{blueprint_id}/nodes/{im_id}",
+        method="PATCH",
+        data={"interfaces": updated_ifaces},
+        params={"allow_unsafe": "true"},
+    )
+    return dict(
+        changed=True,
+        msg=(
+            f"Speed of '{if_name}' on '{system_name}' changed to {speed} "
+            f"(IM setting updated via direct node patch)"
+        ),
+    )
+
+
 def _speed_via_interface_transformation(
     module,
     client_factory,
@@ -659,14 +723,17 @@ def _speed_via_interface_transformation(
     except Exception as exc:
         exc_str = str(exc)
         if "not synced with config" in exc_str.lower() or "staging" in exc_str.lower():
-            module.fail_json(
-                msg=(
-                    f"Cannot change speed of '{if_name}' on '{system_name}': "
-                    f"the blueprint has staged changes that have not been deployed. "
-                    f"Deploy (commit) the blueprint in the Apstra UI or API to sync "
-                    f"staging with the device config, then retry this playbook. "
-                    f"Apstra error: {exc_str}"
-                )
+            return _fix_im_setting_via_patch(
+                module,
+                client,
+                blueprint_id,
+                im_id,
+                system_name,
+                if_name,
+                desired_value,
+                desired_unit,
+                speed,
+                im_node,
             )
         module.fail_json(msg=f"interface-transformation failed: {exc_str}")
 

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -435,20 +435,6 @@ def _handle_absent(module, client_factory):
 # ──────────────────────────────────────────────────────────────────
 
 
-def _get_design_im_list(client_factory):
-    """Return all design interface maps as a list of dicts.
-
-    Uses ``GET /design/interface-maps`` via the l3clos SDK client.
-
-    Returns:
-        list[dict]: Each dict has at least ``id``, ``label``,
-        ``device_profile_id``, ``logical_device_id``, and ``interfaces``.
-    """
-    client = _get_l3clos_client(client_factory)
-    result = client.request("/design/interface-maps", method="GET")
-    return (result or {}).get("items", [])
-
-
 def _get_design_im_detail(client_factory, im_id):
     """Return full details of a design interface map by ID."""
     client = _get_l3clos_client(client_factory)
@@ -467,20 +453,6 @@ def _get_blueprint_im_node(client_factory, blueprint_id, im_id):
     if resp.status_code == 200:
         return resp.json()
     return {}
-
-
-def _get_blueprint_im_nodes(client_factory, blueprint_id):
-    """Return all interface_map nodes defined at the blueprint level.
-
-    Uses ``GET /blueprints/{id}/nodes?node_type=interface_map``.
-    Returns a list of node dicts (may include both design-derived and
-    blueprint-local IMs such as Apstra-created ``_v2`` speed variants).
-    """
-    base = client_factory.get_base_client()
-    resp = base.raw_request(f"/blueprints/{blueprint_id}/nodes?node_type=interface_map")
-    if resp.status_code == 200:
-        return list(resp.json().get("nodes", {}).values())
-    return []
 
 
 def _normalize_speed(speed_str):
@@ -505,40 +477,18 @@ def _normalize_speed(speed_str):
     return int(m.group(1)), m.group(2).upper()
 
 
-def _im_has_speed_for_interface(im_detail, if_name, desired_value, desired_unit):
-    """Return True if this interface map has the desired speed for ``if_name``.
-
-    Checks the ``interfaces`` list in the IM for an entry whose ``name``
-    matches ``if_name`` and whose ``speed.value``/``speed.unit`` match
-    the desired speed.
-    """
-    for intf in im_detail.get("interfaces", []):
-        intf_name = intf.get("name") or intf.get("if_name")
-        if intf_name == if_name:
-            spd = intf.get("speed") or {}
-            if isinstance(spd, dict):
-                if (
-                    spd.get("value") == desired_value
-                    and spd.get("unit", "").upper() == desired_unit
-                ):
-                    return True
-    return False
-
-
 def _im_has_transform_id(im_detail, if_name, transform_id):
-    """Return True if this IM has the specified transform_id for ``if_name``.
+    """Return True if ``if_name`` already uses ``transform_id`` in this IM.
 
-    In newer device profiles, transforms are listed per interface.
-    Falls back to True if the IM's logical_device matches and the
-    transform_id would be valid.
+    Checks ``mapping[1]`` of the interface entry — the index of the
+    currently active transform within the port-group's transforms list.
     """
     for intf in im_detail.get("interfaces", []):
         intf_name = intf.get("name") or intf.get("if_name")
         if intf_name == if_name:
-            transforms = intf.get("transforms", [])
-            for t in transforms:
-                if t.get("id") == transform_id:
-                    return True
+            mapping = intf.get("mapping", [])
+            current_tid = mapping[1] if len(mapping) > 1 else None
+            return current_tid == transform_id
     return False
 
 
@@ -560,15 +510,16 @@ def _resolve_system_node_for_im(client_factory, blueprint_id, system_name):
 
 
 def _handle_speed_updated(module, client_factory):
-    """Handle state=speed_updated — change speed/breakout via interface map.
+    """Handle state=speed_updated — change a link's speed.
 
-    Finds an interface map in the design catalog that satisfies the desired
-    speed (or transform_id) for the specified interface on a system, then
-    re-assigns that interface map to the system node.
+    For ``speed``: queries the blueprint cabling map to find the physical
+    link that includes ``if_name`` on ``system_name``, checks idempotency
+    against the link's current speed, then calls the Apstra WebUI API
+    ``PUT /blueprints/{id}/set-physical-link-speed`` (or
+    ``set-switch-system-link-speed`` for access / generic-system links).
 
-    Idempotency: reads the current assignment and checks whether it
-    already provides the desired speed for the interface.  No change is
-    made if it does.
+    For ``transform_id``: uses ``PUT /blueprints/{id}/interface-transformation``
+    and checks idempotency via the current interface map's ``mapping[1]``.
     """
     p = module.params
     id_param = p["id"] or {}
@@ -594,160 +545,167 @@ def _handle_speed_updated(module, client_factory):
     if speed is not None and transform_id is not None:
         module.fail_json(msg="body.speed and body.transform_id are mutually exclusive")
 
-    # Parse speed if provided
-    desired_value = None
-    desired_unit = None
+    base = client_factory.get_base_client()
+
+    # ── speed path: use set-physical-link-speed (same as Apstra WebUI) ────────
     if speed is not None:
         try:
             desired_value, desired_unit = _normalize_speed(str(speed))
         except ValueError as exc:
             module.fail_json(msg=str(exc))
+        desired_speed_str = f"{desired_value}{desired_unit}"
 
-    # Resolve system node in the blueprint
+        # Fetch cabling map to find the link for this interface
+        resp = base.raw_request(f"/blueprints/{blueprint_id}/cabling-map")
+        if resp.status_code != 200:
+            module.fail_json(
+                msg=f"Failed to get cabling map [{resp.status_code}]: {resp.text[:200]}"
+            )
+        cabling = resp.json()
+
+        link_id = None
+        link_speed = None
+        link_role = None
+        for link in cabling.get("links", []):
+            for ep in link.get("endpoints", []):
+                if (
+                    ep.get("system", {}).get("label") == system_name
+                    and ep.get("interface", {}).get("if_name") == if_name
+                ):
+                    link_id = link["id"]
+                    link_speed = link.get("speed", "")
+                    link_role = link.get("role", "")
+                    break
+            if link_id:
+                break
+
+        if not link_id:
+            module.fail_json(
+                msg=(
+                    f"No physical link found for interface '{if_name}' on "
+                    f"system '{system_name}'. Verify the interface is connected "
+                    f"in the blueprint cabling map."
+                )
+            )
+
+        # Idempotency: current link speed already matches desired
+        if link_speed == desired_speed_str:
+            return dict(
+                changed=False,
+                msg=(
+                    f"Link speed of '{if_name}' on '{system_name}' is already "
+                    f"{speed} (no change)"
+                ),
+            )
+
+        if module.check_mode:
+            return dict(
+                changed=True,
+                msg=(
+                    f"Would change link speed of '{if_name}' on '{system_name}' "
+                    f"from {link_speed} to {speed}"
+                ),
+            )
+
+        # Access / generic-system links use a different endpoint
+        _SWITCH_SYS_ROLES = frozenset({"to_generic", "access_l3", "to_access_switch"})
+        endpoint = (
+            "set-switch-system-link-speed"
+            if link_role in _SWITCH_SYS_ROLES
+            else "set-physical-link-speed"
+        )
+        payload = {
+            "links": [
+                {
+                    "link_id": link_id,
+                    "speed": {"unit": desired_unit, "value": desired_value},
+                }
+            ]
+        }
+        resp = base.raw_request(
+            f"/blueprints/{blueprint_id}/{endpoint}",
+            "PUT",
+            data=payload,
+        )
+        if resp.status_code not in (200, 202, 204):
+            module.fail_json(
+                msg=f"{endpoint} failed [{resp.status_code}]: {resp.text[:300]}"
+            )
+
+        return dict(
+            changed=True,
+            msg=(
+                f"Link speed of '{if_name}' on '{system_name}' changed "
+                f"from {link_speed} to {speed}"
+            ),
+        )
+
+    # ── transform_id path: use interface-transformation ────────────────────────
     node_id = _resolve_system_node_for_im(client_factory, blueprint_id, system_name)
     if not node_id:
         module.fail_json(
             msg=f"System '{system_name}' not found in blueprint '{blueprint_id}'"
         )
 
-    # Get current interface map assignment for this node
+    # Idempotency: check current IM mapping[1] against desired transform_id
     current = _get_assignments(client_factory, blueprint_id)
     current_im_id = current.get(node_id)
-
-    # Get all design interface maps
-    all_ims = _get_design_im_list(client_factory)
-
-    # Fetch current IM detail once (used for idempotency + DP/LD filtering).
-    # Try design catalog first; fall back to blueprint node lookup for
-    # blueprint-local IMs (e.g. Apstra-created ``_v2`` speed variants that
-    # exist only in the blueprint, not in ``/design/interface-maps``).
-    current_im_detail = None
-    current_dp_id = None
-    current_ld_id = None
     if current_im_id:
         current_im_detail = _get_design_im_detail(client_factory, current_im_id)
         if not current_im_detail:
-            # Not in design catalog — look it up as a blueprint node
             current_im_detail = _get_blueprint_im_node(
                 client_factory, blueprint_id, current_im_id
             )
-        current_dp_id = current_im_detail.get("device_profile_id")
-        current_ld_id = current_im_detail.get("logical_device_id")
+        if current_im_detail and _im_has_transform_id(
+            current_im_detail, if_name, transform_id
+        ):
+            return dict(
+                changed=False,
+                system_node_id=node_id,
+                msg=(
+                    f"Interface '{if_name}' on '{system_name}' already uses "
+                    f"transform_id={transform_id} (no change)"
+                ),
+            )
 
-    # If a current IM is assigned, check idempotency first
-    if current_im_detail:
-        if speed is not None:
-            if _im_has_speed_for_interface(
-                current_im_detail, if_name, desired_value, desired_unit
-            ):
-                return dict(
-                    changed=False,
-                    assignments=current,
-                    system_node_id=node_id,
-                    msg=(
-                        f"Interface '{if_name}' on '{system_name}' already uses "
-                        f"interface map '{current_im_id}' which provides "
-                        f"speed {speed} (no change)"
-                    ),
-                )
-        else:
-            if _im_has_transform_id(current_im_detail, if_name, transform_id):
-                return dict(
-                    changed=False,
-                    assignments=current,
-                    system_node_id=node_id,
-                    msg=(
-                        f"Interface '{if_name}' on '{system_name}' already uses "
-                        f"interface map '{current_im_id}' with transform_id={transform_id} "
-                        f"(no change)"
-                    ),
-                )
-
-    # Find best-matching IM in the catalog
-    # Restrict to same device_profile_id AND logical_device_id so the assignment
-    # is accepted by Apstra (cross-LD assignments are rejected with HTTP 422).
-    candidate_im_id = None
-    for im in all_ims:
-        # Only look at IMs for the same device profile
-        if current_dp_id and im.get("device_profile_id") != current_dp_id:
-            continue
-        # Apstra requires the new IM to use the same logical_device_id
-        if current_ld_id and im.get("logical_device_id") != current_ld_id:
-            continue
-
-        im_id = im.get("id")
-        if not im_id:
-            continue
-
-        # Fetch full IM detail to check interfaces
-        im_detail = _get_design_im_detail(client_factory, im_id)
-        if speed is not None:
-            if _im_has_speed_for_interface(
-                im_detail, if_name, desired_value, desired_unit
-            ):
-                candidate_im_id = im_id
-                break
-        else:
-            if _im_has_transform_id(im_detail, if_name, transform_id):
-                candidate_im_id = im_id
-                break
-
-    if not candidate_im_id:
-        # Design catalog has no suitable IM.  Also search blueprint-level IM
-        # nodes — Apstra creates blueprint-local variants (e.g. ``_v2``) when
-        # the WebUI changes a port speed.  These nodes share the same device
-        # profile but may carry a different (derived) logical_device_id, so
-        # we only filter by device_profile_id here.
-        bp_ims = _get_blueprint_im_nodes(client_factory, blueprint_id)
-        for im in bp_ims:
-            im_id = im.get("id")
-            if not im_id or im_id == current_im_id:
-                continue
-            if current_dp_id and im.get("device_profile_id") != current_dp_id:
-                continue
-            # Note: skip the LD filter for blueprint IMs — their LD may differ
-            # from the design LD while still being a valid speed variant.
-            if speed is not None:
-                if _im_has_speed_for_interface(
-                    im, if_name, desired_value, desired_unit
-                ):
-                    candidate_im_id = im_id
-                    break
-            else:
-                if _im_has_transform_id(im, if_name, transform_id):
-                    candidate_im_id = im_id
-                    break
-
-    if not candidate_im_id:
-        criteria = (
-            f"speed={speed}" if speed is not None else f"transform_id={transform_id}"
+    if module.check_mode:
+        return dict(
+            changed=True,
+            system_node_id=node_id,
+            msg=(
+                f"Would apply transformation_id={transform_id} to "
+                f"interface '{if_name}' on '{system_name}'"
+            ),
         )
-        device_info = f" for device profile '{current_dp_id}'" if current_dp_id else ""
-        ld_info = f" with logical_device_id '{current_ld_id}'" if current_ld_id else ""
+
+    payload = {
+        "interfaces": [
+            {
+                "system_id": node_id,
+                "if_name": if_name,
+                "transformation_id": transform_id,
+            }
+        ]
+    }
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/interface-transformation",
+        "PUT",
+        data=payload,
+    )
+    if resp.status_code not in (200, 202, 204):
         module.fail_json(
             msg=(
-                f"No interface map found{device_info}{ld_info} that provides "
-                f"{criteria} for interface '{if_name}'. "
-                f"Create a compatible interface map in the design catalog first."
+                f"interface-transformation failed [{resp.status_code}]: "
+                f"{resp.text[:300]}"
             )
         )
 
-    # Apply the new assignment
-    _patch_assignments(client_factory, blueprint_id, {node_id: candidate_im_id})
-    final = dict(current)
-    final[node_id] = candidate_im_id
-
-    criteria_msg = (
-        f"speed={speed}" if speed is not None else f"transform_id={transform_id}"
-    )
     return dict(
         changed=True,
-        assignments=final,
         system_node_id=node_id,
-        interface_map_id=candidate_im_id,
         msg=(
-            f"Interface '{if_name}' on '{system_name}': assigned interface map "
-            f"'{candidate_im_id}' ({criteria_msg})"
+            f"Applied transformation_id={transform_id} to "
+            f"interface '{if_name}' on '{system_name}'"
         ),
     )
 

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -198,13 +198,20 @@ system_node_id:
   returned: when state is speed_updated
 """
 
-import json
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
     apstra_client_module_args,
     ApstraClientFactory,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_interface_speed import (
+    SpeedChangeError,
+    normalize_speed,
+    change_interface_speed,
+    get_im_for_system,
+    get_effective_im_node,
+    im_has_transform_id,
 )
 
 # ──────────────────────────────────────────────────────────────────
@@ -436,303 +443,12 @@ def _handle_absent(module, client_factory):
 # ──────────────────────────────────────────────────────────────────
 
 
-def _get_design_im_detail(client_factory, im_id):
-    """Return full details of a design interface map by ID."""
-    client = _get_l3clos_client(client_factory)
-    return client.request(f"/design/interface-maps/{im_id}", method="GET") or {}
-
-
-def _get_blueprint_im_node(client_factory, blueprint_id, im_id):
-    """Return a blueprint node of type interface_map by ID.
-
-    Used as fallback when the IM exists only at the blueprint level
-    (e.g. Apstra-created ``_v2`` variants) and is not in the design catalog.
-    Returns an empty dict if not found.
-    """
-    client = _get_l3clos_client(client_factory)
-    try:
-        return (
-            client.request(f"/blueprints/{blueprint_id}/nodes/{im_id}", method="GET")
-            or {}
-        )
-    except Exception:
-        return {}
-
-
-def _normalize_speed(speed_str):
-    """Normalize a speed string like '25G', '25g', '25000M' to uppercase 'G' form.
-
-    Accepted input formats:
-      - ``"25G"`` / ``"25g"`` → ``"25G"``
-      - ``"100G"`` → ``"100G"``
-      - Integer ``{value}`` and unit ``G`` / ``T`` etc.
-
-    Returns:
-        tuple[int, str]: (value, unit) — e.g. (25, "G").
-    """
-    import re
-
-    m = re.match(r"^(\d+)\s*([A-Za-z]+)$", speed_str.strip())
-    if not m:
-        raise ValueError(
-            f"Cannot parse speed '{speed_str}'. "
-            f"Expected format like '25G', '100G', '10G'."
-        )
-    return int(m.group(1)), m.group(2).upper()
-
-
-def _im_has_transform_id(im_detail, if_name, transform_id):
-    """Return True if ``if_name`` already uses ``transform_id`` in this IM.
-
-    Checks ``mapping[1]`` of the interface entry — the index of the
-    currently active transform within the port-group's transforms list.
-    """
-    for intf in im_detail.get("interfaces", []):
-        intf_name = intf.get("name") or intf.get("if_name")
-        if intf_name == if_name:
-            mapping = intf.get("mapping", [])
-            current_tid = mapping[1] if len(mapping) > 1 else None
-            return current_tid == transform_id
-    return False
-
-
-def _resolve_system_node_for_im(client_factory, blueprint_id, system_name):
-    """Resolve a system node label to its blueprint node UUID.
-
-    Returns:
-        str or None: The node UUID, or None if not found.
-    """
-    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
-        run_qe_query,
-    )
-
-    qe = f"node('system', label='{system_name}', name='sys')"
-    items = run_qe_query(client_factory, blueprint_id, qe)
-    if not items:
-        return None
-    return items[0].get("sys", {}).get("id")
-
-
-def _get_dp_ports_from_im(client_factory, blueprint_id, im_id):
-    """Return the device_profile ``ports`` list for the given blueprint IM.
-
-    Traverses the blueprint graph ``interface_map → device_profile`` and
-    returns the device profile's port list (with transformations).
-    Returns an empty list when not found.
-    """
-    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
-        run_qe_query,
-    )
-
-    qe = f"node('interface_map', id='{im_id}', name='im').out().node('device_profile', name='dp')"
-    items = run_qe_query(client_factory, blueprint_id, qe)
-    if not items:
-        return []
-    return items[0].get("dp", {}).get("ports", [])
-
-
-def _find_transform_id_for_speed(dp_ports, if_name, desired_value, desired_unit):
-    """Return the transformation_id for a non-breakout interface at the given speed.
-
-    Searches each port's transformations for one whose sole interface has
-    ``name == if_name`` and speed matching ``(desired_value, desired_unit)``.
-
-    Returns:
-        int or None: The matching transformation_id, or None if not found.
-    """
-    for port in dp_ports:
-        for transform in port.get("transformations", []):
-            ifaces = transform.get("interfaces", [])
-            if len(ifaces) == 1 and ifaces[0].get("name") == if_name:
-                sp = ifaces[0].get("speed", {})
-                if (
-                    sp.get("value") == desired_value
-                    and sp.get("unit", "").upper() == desired_unit
-                ):
-                    return transform["transformation_id"]
-    return None
-
-
-def _list_speeds_for_iface(dp_ports, if_name):
-    """Return unique non-breakout speeds available for ``if_name`` in device profile."""
-    seen = []
-    for port in dp_ports:
-        for transform in port.get("transformations", []):
-            ifaces = transform.get("interfaces", [])
-            if len(ifaces) == 1 and ifaces[0].get("name") == if_name:
-                sp = ifaces[0].get("speed", {})
-                label = f"{sp.get('value', '?')}{sp.get('unit', '')}"
-                if label not in seen:
-                    seen.append(label)
-    return seen
-
-
-def _speed_via_im_backtrace(
-    module,
-    client_factory,
-    blueprint_id,
-    system_name,
-    if_name,
-    desired_value,
-    desired_unit,
-    speed,
-):
-    """Change interface speed by backtracing system_name + if_name to the IM node.
-
-    Used when ``if_name`` is null in the cabling map (Apstra v6.1.1
-    blueprint-local IMs).  Backtraces:
-
-      system_name → system graph node → IM assignment → blueprint IM node
-      → interface entry by name → update ``setting.global.speed``
-      → PATCH ``/blueprints/{id}/nodes/{im_id}?allow_unsafe=true``
-
-    Apstra automatically selects the matching transform_id (``mapping[1]``)
-    for the new speed value, so only ``setting.global.speed`` needs updating.
-
-    Safety guard: only patches interfaces whose ``setting.global`` already
-    contains a ``port`` key (per-port QSFP speed selectors such as
-    ``fpc/pic/port``).  Interfaces without a port selector (e.g. fixed-speed
-    xe copper ports) have no per-port chassis command and must not be patched
-    here — doing so would generate a chassis-wide Junos speed command.
-    """
-    # ── Resolve system_name → IM ───────────────────────────────────────────
-    node_id = _resolve_system_node_for_im(client_factory, blueprint_id, system_name)
-    if not node_id:
-        module.fail_json(
-            msg=f"System '{system_name}' not found in blueprint '{blueprint_id}'"
-        )
-
-    assignments = _get_assignments(client_factory, blueprint_id)
-    im_id = assignments.get(node_id)
-    if not im_id:
-        module.fail_json(
-            msg=f"No interface map assignment found for system '{system_name}'"
-        )
-
-    im_node = _get_blueprint_im_node(client_factory, blueprint_id, im_id)
-    if not im_node:
-        im_node = _get_design_im_detail(client_factory, im_id) or {}
-
-    # ── Find the interface entry by name ───────────────────────────────────
-    target_entry = next(
-        (
-            i
-            for i in im_node.get("interfaces", [])
-            if (i.get("name") or i.get("if_name")) == if_name
-        ),
-        None,
-    )
-    if target_entry is None:
-        module.fail_json(
-            msg=(
-                f"Interface '{if_name}' not found in interface map for "
-                f"'{system_name}'. Verify the interface name matches the "
-                f"device profile."
-            )
-        )
-
-    # ── Safety: require a per-port selector in global setting ──────────────
-    # Interfaces without fpc/pic/port (e.g. fixed-speed xe copper ports) have
-    # no per-port Junos chassis speed command.  Patching global.speed without
-    # a port selector would produce a chassis-wide config change.
-    try:
-        cur_setting = json.loads(
-            target_entry.get("setting", {}).get("param", "{}")
-        )
-    except (ValueError, TypeError):
-        cur_setting = {}
-    if "port" not in cur_setting.get("global", {}):
-        dp_ports = _get_dp_ports_from_im(client_factory, blueprint_id, im_id)
-        available = _list_speeds_for_iface(dp_ports, if_name)
-        module.fail_json(
-            msg=(
-                f"Interface '{if_name}' on '{system_name}' does not have a "
-                f"per-port speed selector in its interface map setting. "
-                f"Per-port speed changes require fpc/pic/port in the global "
-                f"setting (only QSFP/breakout ports support this). "
-                f"Available speeds from device profile: "
-                f"{available or 'none found'}"
-            )
-        )
-
-    # ── Idempotency via setting.global.speed ───────────────────────────────
-    desired_speed_norm = f"{desired_value}{desired_unit.lower()}"
-    cur_speed = cur_setting.get("global", {}).get("speed", "")
-    if cur_speed.lower() == desired_speed_norm.lower():
-        return dict(
-            changed=False,
-            msg=(
-                f"Interface '{if_name}' on '{system_name}' is already "
-                f"{speed} in the interface map (no change)"
-            ),
-        )
-
-    # ── Validate desired speed against device profile ──────────────────────
-    dp_ports = _get_dp_ports_from_im(client_factory, blueprint_id, im_id)
-    transform_id = _find_transform_id_for_speed(
-        dp_ports, if_name, desired_value, desired_unit
-    )
-    if transform_id is None:
-        available = _list_speeds_for_iface(dp_ports, if_name)
-        module.fail_json(
-            msg=(
-                f"Speed {speed} is not valid for interface '{if_name}' on "
-                f"'{system_name}'. "
-                f"Available speeds: {available or 'none found in device profile'}"
-            )
-        )
-
-    if module.check_mode:
-        return dict(
-            changed=True,
-            msg=(
-                f"Would change speed of '{if_name}' on '{system_name}' "
-                f"from {cur_speed or 'unknown'} to {speed}"
-            ),
-        )
-
-    # ── PATCH the IM node — only update global.speed, preserve other keys ──
-    new_global = dict(cur_setting.get("global", {}))
-    new_global["speed"] = desired_speed_norm
-    new_setting = dict(cur_setting)
-    new_setting["global"] = new_global
-
-    updated_ifaces = []
-    for ifc in im_node.get("interfaces", []):
-        if (ifc.get("name") or ifc.get("if_name")) == if_name:
-            ni = dict(ifc)
-            ni["setting"] = {"param": json.dumps(new_setting)}
-            updated_ifaces.append(ni)
-        else:
-            updated_ifaces.append(ifc)
-
-    client = _get_l3clos_client(client_factory)
-    client.request(
-        f"/blueprints/{blueprint_id}/nodes/{im_id}",
-        method="PATCH",
-        data={"interfaces": updated_ifaces},
-        params={"allow_unsafe": "true"},
-    )
-    return dict(
-        changed=True,
-        msg=(
-            f"Speed of '{if_name}' on '{system_name}' changed to {speed} "
-            f"(interface map setting updated)"
-        ),
-    )
-
-
 def _handle_speed_updated(module, client_factory):
     """Handle state=speed_updated — change a link's speed.
 
-    For ``speed``: queries the blueprint cabling map to find the physical
-    link that includes ``if_name`` on ``system_name``, checks idempotency
-    against the link's current speed, then calls the Apstra WebUI API
-    ``PUT /blueprints/{id}/set-physical-link-speed`` (or
-    ``set-switch-system-link-speed`` for access / generic-system links).
-
-    For ``transform_id``: uses ``PUT /blueprints/{id}/interface-transformation``
-    and checks idempotency via the current interface map's ``mapping[1]``.
+    Delegates to ``bp_interface_speed.change_interface_speed`` for the
+    ``speed`` parameter path and uses ``interface-transformation`` for
+    ``transform_id``.
     """
     p = module.params
     id_param = p["id"] or {}
@@ -758,159 +474,65 @@ def _handle_speed_updated(module, client_factory):
     if speed is not None and transform_id is not None:
         module.fail_json(msg="body.speed and body.transform_id are mutually exclusive")
 
-    client = _get_l3clos_client(client_factory)
-
-    # ── speed path: use set-physical-link-speed (same as Apstra WebUI) ────────
+    # ── speed path: delegate to bp_interface_speed ─────────────────────────
     if speed is not None:
         try:
-            desired_value, desired_unit = _normalize_speed(str(speed))
-        except ValueError as exc:
+            desired_value, desired_unit = normalize_speed(str(speed))
+        except SpeedChangeError as exc:
             module.fail_json(msg=str(exc))
-        desired_speed_str = f"{desired_value}{desired_unit}"
 
-        # Fetch cabling map to find the link for this interface
-        cabling = (
-            client.request(f"/blueprints/{blueprint_id}/cabling-map", method="GET")
-            or {}
+        try:
+            return change_interface_speed(
+                client_factory,
+                blueprint_id,
+                system_name,
+                if_name,
+                desired_value,
+                desired_unit,
+                str(speed),
+                module.check_mode,
+            )
+        except SpeedChangeError as exc:
+            module.fail_json(msg=str(exc))
+
+    # ── transform_id path: use interface-transformation ────────────────────
+    try:
+        system_node_id, im_id = get_im_for_system(
+            client_factory, blueprint_id, system_name
         )
+    except SpeedChangeError as exc:
+        module.fail_json(msg=str(exc))
 
-        link_id = None
-        link_speed = None
-        link_role = None
-        # Links where endpoint matches system but if_name is None (Apstra v6.1.1
-        # blueprint-local IMs do not populate if_name in the cabling map).
-        null_name_candidates = []
-        for link in cabling.get("links", []):
-            for ep in link.get("endpoints", []):
-                if ep.get("system", {}).get("label") == system_name:
-                    ep_if_name = ep.get("interface", {}).get("if_name")
-                    if ep_if_name == if_name:
-                        # Exact match — primary path
-                        link_id = link["id"]
-                        link_speed = link.get("speed", "")
-                        link_role = link.get("role", "")
-                        break
-                    elif ep_if_name is None:
-                        null_name_candidates.append(
-                            (link["id"], link.get("speed", ""), link.get("role", ""))
-                        )
-            if link_id:
-                break
+    try:
+        im_node = get_effective_im_node(client_factory, blueprint_id, im_id)
+    except SpeedChangeError as exc:
+        module.fail_json(msg=str(exc))
 
-        # Fallback: blueprint-local IMs in Apstra v6.1.1 may leave if_name as
-        # null in the cabling map.  Accept the single candidate if unambiguous.
-        if not link_id:
-            if len(null_name_candidates) == 1:
-                link_id, link_speed, link_role = null_name_candidates[0]
-            elif len(null_name_candidates) > 1:
-                # Blueprint-local IM (Apstra v6.1.1): if_name is null in the
-                # cabling map for all physical port endpoints.  Backtrace from
-                # system_name + if_name directly to the IM node and patch the
-                # setting — no link_id needed.
-                return _speed_via_im_backtrace(
-                    module,
-                    client_factory,
-                    blueprint_id,
-                    system_name,
-                    if_name,
-                    desired_value,
-                    desired_unit,
-                    speed,
-                )
-
-        if not link_id:
-            module.fail_json(
-                msg=(
-                    f"No physical link found for interface '{if_name}' on "
-                    f"system '{system_name}'. Verify the interface is connected "
-                    f"in the blueprint cabling map."
-                )
-            )
-
-        # Idempotency: current link speed already matches desired
-        if link_speed == desired_speed_str:
-            return dict(
-                changed=False,
-                msg=(
-                    f"Link speed of '{if_name}' on '{system_name}' is already "
-                    f"{speed} (no change)"
-                ),
-            )
-
-        if module.check_mode:
-            return dict(
-                changed=True,
-                msg=(
-                    f"Would change link speed of '{if_name}' on '{system_name}' "
-                    f"from {link_speed} to {speed}"
-                ),
-            )
-
-        # Access / generic-system links use a different SDK method
-        _SWITCH_SYS_ROLES = frozenset({"to_generic", "access_l3", "to_access_switch"})
-        payload = {
-            "links": [
-                {
-                    "link_id": link_id,
-                    "speed": {"unit": desired_unit, "value": desired_value},
-                }
-            ]
-        }
-        if link_role in _SWITCH_SYS_ROLES:
-            client.blueprints[blueprint_id].set_switch_system_link_speed(payload)
-        else:
-            client.blueprints[blueprint_id].set_physical_link_speed(payload)
-
+    if im_has_transform_id(im_node, if_name, transform_id):
         return dict(
-            changed=True,
+            changed=False,
+            system_node_id=system_node_id,
             msg=(
-                f"Link speed of '{if_name}' on '{system_name}' changed "
-                f"from {link_speed} to {speed}"
+                f"Interface '{if_name}' on '{system_name}' already uses "
+                f"transform_id={transform_id} (no change)"
             ),
         )
-
-    # ── transform_id path: use interface-transformation ────────────────────────
-    node_id = _resolve_system_node_for_im(client_factory, blueprint_id, system_name)
-    if not node_id:
-        module.fail_json(
-            msg=f"System '{system_name}' not found in blueprint '{blueprint_id}'"
-        )
-
-    # Idempotency: check current IM mapping[1] against desired transform_id
-    current = _get_assignments(client_factory, blueprint_id)
-    current_im_id = current.get(node_id)
-    if current_im_id:
-        current_im_detail = _get_design_im_detail(client_factory, current_im_id)
-        if not current_im_detail:
-            current_im_detail = _get_blueprint_im_node(
-                client_factory, blueprint_id, current_im_id
-            )
-        if current_im_detail and _im_has_transform_id(
-            current_im_detail, if_name, transform_id
-        ):
-            return dict(
-                changed=False,
-                system_node_id=node_id,
-                msg=(
-                    f"Interface '{if_name}' on '{system_name}' already uses "
-                    f"transform_id={transform_id} (no change)"
-                ),
-            )
 
     if module.check_mode:
         return dict(
             changed=True,
-            system_node_id=node_id,
+            system_node_id=system_node_id,
             msg=(
                 f"Would apply transformation_id={transform_id} to "
                 f"interface '{if_name}' on '{system_name}'"
             ),
         )
 
+    client = _get_l3clos_client(client_factory)
     payload = {
         "interfaces": [
             {
-                "system_id": node_id,
+                "system_id": system_node_id,
                 "if_name": if_name,
                 "transformation_id": transform_id,
             }
@@ -920,7 +542,7 @@ def _handle_speed_updated(module, client_factory):
 
     return dict(
         changed=True,
-        system_node_id=node_id,
+        system_node_id=system_node_id,
         msg=(
             f"Applied transformation_id={transform_id} to "
             f"interface '{if_name}' on '{system_name}'"

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -512,6 +512,159 @@ def _resolve_system_node_for_im(client_factory, blueprint_id, system_name):
     return items[0].get("sys", {}).get("id")
 
 
+def _get_dp_ports_from_im(client_factory, blueprint_id, im_id):
+    """Return the device_profile ``ports`` list for the given blueprint IM.
+
+    Traverses the blueprint graph ``interface_map → device_profile`` and
+    returns the device profile's port list (with transformations).
+    Returns an empty list when not found.
+    """
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_query import (
+        run_qe_query,
+    )
+
+    qe = f"node('interface_map', id='{im_id}', name='im').out().node('device_profile', name='dp')"
+    items = run_qe_query(client_factory, blueprint_id, qe)
+    if not items:
+        return []
+    return items[0].get("dp", {}).get("ports", [])
+
+
+def _find_transform_id_for_speed(dp_ports, if_name, desired_value, desired_unit):
+    """Return the transformation_id for a non-breakout interface at the given speed.
+
+    Searches each port's transformations for one whose sole interface has
+    ``name == if_name`` and speed matching ``(desired_value, desired_unit)``.
+
+    Returns:
+        int or None: The matching transformation_id, or None if not found.
+    """
+    for port in dp_ports:
+        for transform in port.get("transformations", []):
+            ifaces = transform.get("interfaces", [])
+            if len(ifaces) == 1 and ifaces[0].get("name") == if_name:
+                sp = ifaces[0].get("speed", {})
+                if (
+                    sp.get("value") == desired_value
+                    and sp.get("unit", "").upper() == desired_unit
+                ):
+                    return transform["transformation_id"]
+    return None
+
+
+def _list_speeds_for_iface(dp_ports, if_name):
+    """Return unique non-breakout speeds available for ``if_name`` in device profile."""
+    seen = []
+    for port in dp_ports:
+        for transform in port.get("transformations", []):
+            ifaces = transform.get("interfaces", [])
+            if len(ifaces) == 1 and ifaces[0].get("name") == if_name:
+                sp = ifaces[0].get("speed", {})
+                label = f"{sp.get('value', '?')}{sp.get('unit', '')}"
+                if label not in seen:
+                    seen.append(label)
+    return seen
+
+
+def _speed_via_interface_transformation(
+    module,
+    client_factory,
+    blueprint_id,
+    system_name,
+    if_name,
+    desired_value,
+    desired_unit,
+    desired_speed_str,
+    speed,
+):
+    """Change speed via interface-transformation for blueprint-local IMs.
+
+    Used when ``if_name`` is null in the cabling map (Apstra v6.1.1
+    blueprint-local IMs).  Resolves the transformation_id for the desired
+    speed from the device profile and applies it via
+    ``PUT /blueprints/{id}/interface-transformation``.
+    Apstra resolves ``(system_id, if_name)`` internally even when the
+    graph interface node has ``if_name=None``.
+    """
+    node_id = _resolve_system_node_for_im(client_factory, blueprint_id, system_name)
+    if not node_id:
+        module.fail_json(
+            msg=f"System '{system_name}' not found in blueprint '{blueprint_id}'"
+        )
+
+    assignments = _get_assignments(client_factory, blueprint_id)
+    im_id = assignments.get(node_id)
+    if not im_id:
+        module.fail_json(
+            msg=f"No interface map assignment found for system '{system_name}'"
+        )
+
+    # Idempotency: check current IM speed for this interface
+    im_node = _get_blueprint_im_node(client_factory, blueprint_id, im_id)
+    if not im_node:
+        im_node = _get_design_im_detail(client_factory, im_id) or {}
+    for intf in im_node.get("interfaces", []):
+        intf_name = intf.get("name") or intf.get("if_name")
+        if intf_name == if_name:
+            cur = intf.get("speed", {})
+            if (
+                str(cur.get("value", "")) == str(desired_value)
+                and cur.get("unit", "").upper() == desired_unit
+            ):
+                return dict(
+                    changed=False,
+                    msg=(
+                        f"Interface '{if_name}' on '{system_name}' is already "
+                        f"{speed} in the interface map (no change)"
+                    ),
+                )
+            break
+
+    # Look up the transformation_id that sets the desired speed
+    dp_ports = _get_dp_ports_from_im(client_factory, blueprint_id, im_id)
+    transform_id = _find_transform_id_for_speed(
+        dp_ports, if_name, desired_value, desired_unit
+    )
+    if transform_id is None:
+        available = _list_speeds_for_iface(dp_ports, if_name)
+        module.fail_json(
+            msg=(
+                f"Cannot find a transformation for interface '{if_name}' with "
+                f"speed {speed} on '{system_name}'. "
+                f"Available speeds: {available or 'none found in device profile'}"
+            )
+        )
+
+    if module.check_mode:
+        return dict(
+            changed=True,
+            msg=(
+                f"Would change speed of '{if_name}' on '{system_name}' to {speed} "
+                f"(transformation_id={transform_id})"
+            ),
+        )
+
+    client = _get_l3clos_client(client_factory)
+    payload = {
+        "interfaces": [
+            {
+                "system_id": node_id,
+                "if_name": if_name,
+                "transformation_id": transform_id,
+            }
+        ]
+    }
+    client.blueprints[blueprint_id].interface_transformation.put(payload)
+
+    return dict(
+        changed=True,
+        msg=(
+            f"Speed of '{if_name}' on '{system_name}' changed to {speed} "
+            f"via interface-transformation (transformation_id={transform_id})"
+        ),
+    )
+
+
 def _handle_speed_updated(module, client_factory):
     """Handle state=speed_updated — change a link's speed.
 
@@ -593,14 +746,20 @@ def _handle_speed_updated(module, client_factory):
             if len(null_name_candidates) == 1:
                 link_id, link_speed, link_role = null_name_candidates[0]
             elif len(null_name_candidates) > 1:
-                module.fail_json(
-                    msg=(
-                        f"Found {len(null_name_candidates)} physical links for "
-                        f"system '{system_name}' whose interface names are not "
-                        f"stored in the cabling map. Cannot determine which link "
-                        f"corresponds to '{if_name}'. Please ensure the blueprint "
-                        f"is committed and interface maps are resolved."
-                    )
+                # Blueprint-local IM (Apstra v6.1.1): if_name is null in the
+                # cabling map for all physical port endpoints.  Fall back to
+                # interface-transformation — Apstra resolves (system_id, if_name)
+                # internally from the IM even when graph if_name is None.
+                return _speed_via_interface_transformation(
+                    module,
+                    client_factory,
+                    blueprint_id,
+                    system_name,
+                    if_name,
+                    desired_value,
+                    desired_unit,
+                    desired_speed_str,
+                    speed,
                 )
 
         if not link_id:

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -567,70 +567,7 @@ def _list_speeds_for_iface(dp_ports, if_name):
     return seen
 
 
-def _fix_im_setting_via_patch(
-    module,
-    client,
-    blueprint_id,
-    im_id,
-    system_name,
-    if_name,
-    desired_value,
-    desired_unit,
-    speed,
-    im_node,
-):
-    """Change IM interface speed via a direct node PATCH with allow_unsafe=true.
-
-    Called when ``interface-transformation`` returns a "staging not synced"
-    error.  Updating ``setting.global.speed`` on the IM node directly
-    bypasses that check, and Apstra automatically selects the matching
-    transform_id (``mapping[1]``) for the new speed.
-    """
-    im_ifaces = im_node.get("interfaces", [])
-    target_entry = next(
-        (i for i in im_ifaces if (i.get("name") or i.get("if_name")) == if_name),
-        None,
-    )
-    if target_entry is None:
-        module.fail_json(
-            msg=(
-                f"Interface '{if_name}' not found in interface map for "
-                f"'{system_name}'"
-            )
-        )
-
-    speed_str = f"{desired_value}{desired_unit.lower()}"
-    updated_ifaces = []
-    for ifc in im_ifaces:
-        if (ifc.get("name") or ifc.get("if_name")) == if_name:
-            ni = dict(ifc)
-            try:
-                setting = json.loads(ni.get("setting", {}).get("param", "{}"))
-            except (ValueError, TypeError):
-                setting = {}
-            setting.setdefault("global", {})["speed"] = speed_str
-            setting.setdefault("interface", {"speed": ""})
-            ni["setting"] = {"param": json.dumps(setting)}
-            updated_ifaces.append(ni)
-        else:
-            updated_ifaces.append(ifc)
-
-    client.request(
-        f"/blueprints/{blueprint_id}/nodes/{im_id}",
-        method="PATCH",
-        data={"interfaces": updated_ifaces},
-        params={"allow_unsafe": "true"},
-    )
-    return dict(
-        changed=True,
-        msg=(
-            f"Speed of '{if_name}' on '{system_name}' changed to {speed} "
-            f"(IM setting updated via direct node patch)"
-        ),
-    )
-
-
-def _speed_via_interface_transformation(
+def _speed_via_im_backtrace(
     module,
     client_factory,
     blueprint_id,
@@ -638,18 +575,27 @@ def _speed_via_interface_transformation(
     if_name,
     desired_value,
     desired_unit,
-    desired_speed_str,
     speed,
 ):
-    """Change speed via interface-transformation for blueprint-local IMs.
+    """Change interface speed by backtracing system_name + if_name to the IM node.
 
     Used when ``if_name`` is null in the cabling map (Apstra v6.1.1
-    blueprint-local IMs).  Resolves the transformation_id for the desired
-    speed from the device profile and applies it via
-    ``PUT /blueprints/{id}/interface-transformation``.
-    Apstra resolves ``(system_id, if_name)`` internally even when the
-    graph interface node has ``if_name=None``.
+    blueprint-local IMs).  Backtraces:
+
+      system_name → system graph node → IM assignment → blueprint IM node
+      → interface entry by name → update ``setting.global.speed``
+      → PATCH ``/blueprints/{id}/nodes/{im_id}?allow_unsafe=true``
+
+    Apstra automatically selects the matching transform_id (``mapping[1]``)
+    for the new speed value, so only ``setting.global.speed`` needs updating.
+
+    Safety guard: only patches interfaces whose ``setting.global`` already
+    contains a ``port`` key (per-port QSFP speed selectors such as
+    ``fpc/pic/port``).  Interfaces without a port selector (e.g. fixed-speed
+    xe copper ports) have no per-port chassis command and must not be patched
+    here — doing so would generate a chassis-wide Junos speed command.
     """
+    # ── Resolve system_name → IM ───────────────────────────────────────────
     node_id = _resolve_system_node_for_im(client_factory, blueprint_id, system_name)
     if not node_id:
         module.fail_json(
@@ -663,28 +609,65 @@ def _speed_via_interface_transformation(
             msg=f"No interface map assignment found for system '{system_name}'"
         )
 
-    # Idempotency: check current IM speed for this interface
     im_node = _get_blueprint_im_node(client_factory, blueprint_id, im_id)
     if not im_node:
         im_node = _get_design_im_detail(client_factory, im_id) or {}
-    for intf in im_node.get("interfaces", []):
-        intf_name = intf.get("name") or intf.get("if_name")
-        if intf_name == if_name:
-            cur = intf.get("speed", {})
-            if (
-                str(cur.get("value", "")) == str(desired_value)
-                and cur.get("unit", "").upper() == desired_unit
-            ):
-                return dict(
-                    changed=False,
-                    msg=(
-                        f"Interface '{if_name}' on '{system_name}' is already "
-                        f"{speed} in the interface map (no change)"
-                    ),
-                )
-            break
 
-    # Look up the transformation_id that sets the desired speed
+    # ── Find the interface entry by name ───────────────────────────────────
+    target_entry = next(
+        (
+            i
+            for i in im_node.get("interfaces", [])
+            if (i.get("name") or i.get("if_name")) == if_name
+        ),
+        None,
+    )
+    if target_entry is None:
+        module.fail_json(
+            msg=(
+                f"Interface '{if_name}' not found in interface map for "
+                f"'{system_name}'. Verify the interface name matches the "
+                f"device profile."
+            )
+        )
+
+    # ── Safety: require a per-port selector in global setting ──────────────
+    # Interfaces without fpc/pic/port (e.g. fixed-speed xe copper ports) have
+    # no per-port Junos chassis speed command.  Patching global.speed without
+    # a port selector would produce a chassis-wide config change.
+    try:
+        cur_setting = json.loads(
+            target_entry.get("setting", {}).get("param", "{}")
+        )
+    except (ValueError, TypeError):
+        cur_setting = {}
+    if "port" not in cur_setting.get("global", {}):
+        dp_ports = _get_dp_ports_from_im(client_factory, blueprint_id, im_id)
+        available = _list_speeds_for_iface(dp_ports, if_name)
+        module.fail_json(
+            msg=(
+                f"Interface '{if_name}' on '{system_name}' does not have a "
+                f"per-port speed selector in its interface map setting. "
+                f"Per-port speed changes require fpc/pic/port in the global "
+                f"setting (only QSFP/breakout ports support this). "
+                f"Available speeds from device profile: "
+                f"{available or 'none found'}"
+            )
+        )
+
+    # ── Idempotency via setting.global.speed ───────────────────────────────
+    desired_speed_norm = f"{desired_value}{desired_unit.lower()}"
+    cur_speed = cur_setting.get("global", {}).get("speed", "")
+    if cur_speed.lower() == desired_speed_norm.lower():
+        return dict(
+            changed=False,
+            msg=(
+                f"Interface '{if_name}' on '{system_name}' is already "
+                f"{speed} in the interface map (no change)"
+            ),
+        )
+
+    # ── Validate desired speed against device profile ──────────────────────
     dp_ports = _get_dp_ports_from_im(client_factory, blueprint_id, im_id)
     transform_id = _find_transform_id_for_speed(
         dp_ports, if_name, desired_value, desired_unit
@@ -693,8 +676,8 @@ def _speed_via_interface_transformation(
         available = _list_speeds_for_iface(dp_ports, if_name)
         module.fail_json(
             msg=(
-                f"Cannot find a transformation for interface '{if_name}' with "
-                f"speed {speed} on '{system_name}'. "
+                f"Speed {speed} is not valid for interface '{if_name}' on "
+                f"'{system_name}'. "
                 f"Available speeds: {available or 'none found in device profile'}"
             )
         )
@@ -703,45 +686,38 @@ def _speed_via_interface_transformation(
         return dict(
             changed=True,
             msg=(
-                f"Would change speed of '{if_name}' on '{system_name}' to {speed} "
-                f"(transformation_id={transform_id})"
+                f"Would change speed of '{if_name}' on '{system_name}' "
+                f"from {cur_speed or 'unknown'} to {speed}"
             ),
         )
 
-    client = _get_l3clos_client(client_factory)
-    payload = {
-        "interfaces": [
-            {
-                "system_id": node_id,
-                "if_name": if_name,
-                "transformation_id": transform_id,
-            }
-        ]
-    }
-    try:
-        client.blueprints[blueprint_id].interface_transformation.put(payload)
-    except Exception as exc:
-        exc_str = str(exc)
-        if "not synced with config" in exc_str.lower() or "staging" in exc_str.lower():
-            return _fix_im_setting_via_patch(
-                module,
-                client,
-                blueprint_id,
-                im_id,
-                system_name,
-                if_name,
-                desired_value,
-                desired_unit,
-                speed,
-                im_node,
-            )
-        module.fail_json(msg=f"interface-transformation failed: {exc_str}")
+    # ── PATCH the IM node — only update global.speed, preserve other keys ──
+    new_global = dict(cur_setting.get("global", {}))
+    new_global["speed"] = desired_speed_norm
+    new_setting = dict(cur_setting)
+    new_setting["global"] = new_global
 
+    updated_ifaces = []
+    for ifc in im_node.get("interfaces", []):
+        if (ifc.get("name") or ifc.get("if_name")) == if_name:
+            ni = dict(ifc)
+            ni["setting"] = {"param": json.dumps(new_setting)}
+            updated_ifaces.append(ni)
+        else:
+            updated_ifaces.append(ifc)
+
+    client = _get_l3clos_client(client_factory)
+    client.request(
+        f"/blueprints/{blueprint_id}/nodes/{im_id}",
+        method="PATCH",
+        data={"interfaces": updated_ifaces},
+        params={"allow_unsafe": "true"},
+    )
     return dict(
         changed=True,
         msg=(
             f"Speed of '{if_name}' on '{system_name}' changed to {speed} "
-            f"via interface-transformation (transformation_id={transform_id})"
+            f"(interface map setting updated)"
         ),
     )
 
@@ -828,10 +804,10 @@ def _handle_speed_updated(module, client_factory):
                 link_id, link_speed, link_role = null_name_candidates[0]
             elif len(null_name_candidates) > 1:
                 # Blueprint-local IM (Apstra v6.1.1): if_name is null in the
-                # cabling map for all physical port endpoints.  Fall back to
-                # interface-transformation — Apstra resolves (system_id, if_name)
-                # internally from the IM even when graph if_name is None.
-                return _speed_via_interface_transformation(
+                # cabling map for all physical port endpoints.  Backtrace from
+                # system_name + if_name directly to the IM node and patch the
+                # setting — no link_id needed.
+                return _speed_via_im_backtrace(
                     module,
                     client_factory,
                     blueprint_id,
@@ -839,7 +815,6 @@ def _handle_speed_updated(module, client_factory):
                     if_name,
                     desired_value,
                     desired_unit,
-                    desired_speed_str,
                     speed,
                 )
 

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -567,18 +567,41 @@ def _handle_speed_updated(module, client_factory):
         link_id = None
         link_speed = None
         link_role = None
+        # Links where endpoint matches system but if_name is None (Apstra v6.1.1
+        # blueprint-local IMs do not populate if_name in the cabling map).
+        null_name_candidates = []
         for link in cabling.get("links", []):
             for ep in link.get("endpoints", []):
-                if (
-                    ep.get("system", {}).get("label") == system_name
-                    and ep.get("interface", {}).get("if_name") == if_name
-                ):
-                    link_id = link["id"]
-                    link_speed = link.get("speed", "")
-                    link_role = link.get("role", "")
-                    break
+                if ep.get("system", {}).get("label") == system_name:
+                    ep_if_name = ep.get("interface", {}).get("if_name")
+                    if ep_if_name == if_name:
+                        # Exact match — primary path
+                        link_id = link["id"]
+                        link_speed = link.get("speed", "")
+                        link_role = link.get("role", "")
+                        break
+                    elif ep_if_name is None:
+                        null_name_candidates.append(
+                            (link["id"], link.get("speed", ""), link.get("role", ""))
+                        )
             if link_id:
                 break
+
+        # Fallback: blueprint-local IMs in Apstra v6.1.1 may leave if_name as
+        # null in the cabling map.  Accept the single candidate if unambiguous.
+        if not link_id:
+            if len(null_name_candidates) == 1:
+                link_id, link_speed, link_role = null_name_candidates[0]
+            elif len(null_name_candidates) > 1:
+                module.fail_json(
+                    msg=(
+                        f"Found {len(null_name_candidates)} physical links for "
+                        f"system '{system_name}' whose interface names are not "
+                        f"stored in the cabling map. Cannot determine which link "
+                        f"corresponds to '{if_name}'. Please ensure the blueprint "
+                        f"is committed and interface maps are resolved."
+                    )
+                )
 
         if not link_id:
             module.fail_json(

--- a/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/interface_map.py
@@ -448,11 +448,14 @@ def _get_blueprint_im_node(client_factory, blueprint_id, im_id):
     (e.g. Apstra-created ``_v2`` variants) and is not in the design catalog.
     Returns an empty dict if not found.
     """
-    base = client_factory.get_base_client()
-    resp = base.raw_request(f"/blueprints/{blueprint_id}/nodes/{im_id}")
-    if resp.status_code == 200:
-        return resp.json()
-    return {}
+    client = _get_l3clos_client(client_factory)
+    try:
+        return (
+            client.request(f"/blueprints/{blueprint_id}/nodes/{im_id}", method="GET")
+            or {}
+        )
+    except Exception:
+        return {}
 
 
 def _normalize_speed(speed_str):
@@ -545,7 +548,7 @@ def _handle_speed_updated(module, client_factory):
     if speed is not None and transform_id is not None:
         module.fail_json(msg="body.speed and body.transform_id are mutually exclusive")
 
-    base = client_factory.get_base_client()
+    client = _get_l3clos_client(client_factory)
 
     # ── speed path: use set-physical-link-speed (same as Apstra WebUI) ────────
     if speed is not None:
@@ -556,12 +559,10 @@ def _handle_speed_updated(module, client_factory):
         desired_speed_str = f"{desired_value}{desired_unit}"
 
         # Fetch cabling map to find the link for this interface
-        resp = base.raw_request(f"/blueprints/{blueprint_id}/cabling-map")
-        if resp.status_code != 200:
-            module.fail_json(
-                msg=f"Failed to get cabling map [{resp.status_code}]: {resp.text[:200]}"
-            )
-        cabling = resp.json()
+        cabling = (
+            client.request(f"/blueprints/{blueprint_id}/cabling-map", method="GET")
+            or {}
+        )
 
         link_id = None
         link_speed = None
@@ -607,13 +608,8 @@ def _handle_speed_updated(module, client_factory):
                 ),
             )
 
-        # Access / generic-system links use a different endpoint
+        # Access / generic-system links use a different SDK method
         _SWITCH_SYS_ROLES = frozenset({"to_generic", "access_l3", "to_access_switch"})
-        endpoint = (
-            "set-switch-system-link-speed"
-            if link_role in _SWITCH_SYS_ROLES
-            else "set-physical-link-speed"
-        )
         payload = {
             "links": [
                 {
@@ -622,15 +618,10 @@ def _handle_speed_updated(module, client_factory):
                 }
             ]
         }
-        resp = base.raw_request(
-            f"/blueprints/{blueprint_id}/{endpoint}",
-            "PUT",
-            data=payload,
-        )
-        if resp.status_code not in (200, 202, 204):
-            module.fail_json(
-                msg=f"{endpoint} failed [{resp.status_code}]: {resp.text[:300]}"
-            )
+        if link_role in _SWITCH_SYS_ROLES:
+            client.blueprints[blueprint_id].set_switch_system_link_speed(payload)
+        else:
+            client.blueprints[blueprint_id].set_physical_link_speed(payload)
 
         return dict(
             changed=True,
@@ -687,18 +678,7 @@ def _handle_speed_updated(module, client_factory):
             }
         ]
     }
-    resp = base.raw_request(
-        f"/blueprints/{blueprint_id}/interface-transformation",
-        "PUT",
-        data=payload,
-    )
-    if resp.status_code not in (200, 202, 204):
-        module.fail_json(
-            msg=(
-                f"interface-transformation failed [{resp.status_code}]: "
-                f"{resp.text[:300]}"
-            )
-        )
+    client.blueprints[blueprint_id].interface_transformation.put(payload)
 
     return dict(
         changed=True,

--- a/ansible_collections/juniper/apstra/tests/interface.yml
+++ b/ansible_collections/juniper/apstra/tests/interface.yml
@@ -222,6 +222,7 @@
     - name: "[SETUP] Set test interface names"
       ansible.builtin.set_fact:
         test_eth_if: "{{ eth_ifaces_qe.results[0]['iface']['if_name'] }}"
+        test_eth_if2: "{{ eth_ifaces_qe.results[1]['iface']['if_name'] }}"
         test_lag_if: "{{ lag_ifaces_qe.results[0]['iface']['if_name'] }}"
 
     - name: "[SETUP] Display test system and interfaces"
@@ -229,6 +230,7 @@
         msg: >-
           system={{ test_system_name }},
           ethernet_if={{ test_eth_if }},
+          ethernet_if2={{ test_eth_if2 }},
           lag_if={{ test_lag_if }}
 
     # ════════════════════════════════════════════════════════════════
@@ -312,6 +314,78 @@
           - not noshut_idem_result.changed
         fail_msg: "INTF-SHUT-4 FAILED: expected changed=False (idempotent)"
         success_msg: "INTF-SHUT-4 PASSED: Idempotent no-shut"
+
+    - name: "[INTF-BATCH-1] Shut two interfaces via batch interfaces list"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        interfaces:
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if }}"
+            admin_state: "down"
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if2 }}"
+            admin_state: "down"
+        state: interface_updated
+        auth_token: "{{ auth.token }}"
+      register: batch_shut_result
+
+    - name: "[INTF-BATCH-1] Display result"
+      ansible.builtin.debug:
+        var: batch_shut_result
+
+    - name: "[INTF-BATCH-1] Assert changed and both interfaces appear in result"
+      ansible.builtin.assert:
+        that:
+          - batch_shut_result.changed
+          - batch_shut_result.interfaces | length == 2
+        fail_msg: "INTF-BATCH-1 FAILED: expected changed=True and 2 interfaces"
+        success_msg: "INTF-BATCH-1 PASSED: Batch shut applied"
+
+    - name: "[INTF-BATCH-2] Batch shut again (idempotent)"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        interfaces:
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if }}"
+            admin_state: "down"
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if2 }}"
+            admin_state: "down"
+        state: interface_updated
+        auth_token: "{{ auth.token }}"
+      register: batch_idem_result
+
+    - name: "[INTF-BATCH-2] Assert no change"
+      ansible.builtin.assert:
+        that:
+          - not batch_idem_result.changed
+        fail_msg: "INTF-BATCH-2 FAILED: expected changed=False (idempotent)"
+        success_msg: "INTF-BATCH-2 PASSED: Idempotent batch shut"
+
+    - name: "[INTF-BATCH-3] Restore interfaces via batch"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        interfaces:
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if }}"
+            admin_state: "up"
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if2 }}"
+            admin_state: "up"
+        state: interface_updated
+        auth_token: "{{ auth.token }}"
+      register: batch_restore_result
+
+    - name: "[INTF-BATCH-3] Assert both restored"
+      ansible.builtin.assert:
+        that:
+          - batch_restore_result.changed
+          - batch_restore_result.interfaces | length == 2
+        fail_msg: "INTF-BATCH-3 FAILED: expected changed=True and 2 interfaces"
+        success_msg: "INTF-BATCH-3 PASSED: Batch restore applied"
 
     # ════════════════════════════════════════════════════════════════
     #  FEATURE 3: Interface tags

--- a/ansible_collections/juniper/apstra/tests/interface.yml
+++ b/ansible_collections/juniper/apstra/tests/interface.yml
@@ -522,6 +522,91 @@
         success_msg: "INTF-TAG-6 PASSED: All tags cleared"
 
     # ════════════════════════════════════════════════════════════════
+    #  FEATURE 3b: Interface tags — batch mode
+    # ════════════════════════════════════════════════════════════════
+
+    - name: "[INTF-TAG-BATCH-1] Add tags to two interfaces in one task"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        interfaces:
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if }}"
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if2 }}"
+        tags:
+          - "batch-tag-a"
+          - "batch-tag-b"
+        tag_state: present
+        state: interface_tagged
+        auth_token: "{{ auth.token }}"
+      register: tag_batch_add
+
+    - name: "[INTF-TAG-BATCH-1] Assert both interfaces changed"
+      ansible.builtin.assert:
+        that:
+          - tag_batch_add.changed
+          - tag_batch_add.interfaces | length == 2
+          - tag_batch_add.interfaces[0].changed
+          - tag_batch_add.interfaces[1].changed
+        fail_msg: "INTF-TAG-BATCH-1 FAILED"
+        success_msg: "INTF-TAG-BATCH-1 PASSED: Tags added to both interfaces"
+
+    - name: "[INTF-TAG-BATCH-2] Re-add same tags (idempotent)"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        interfaces:
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if }}"
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if2 }}"
+        tags:
+          - "batch-tag-a"
+          - "batch-tag-b"
+        tag_state: present
+        state: interface_tagged
+        auth_token: "{{ auth.token }}"
+      register: tag_batch_idem
+
+    - name: "[INTF-TAG-BATCH-2] Assert no change (idempotent)"
+      ansible.builtin.assert:
+        that:
+          - not tag_batch_idem.changed
+          - not tag_batch_idem.interfaces[0].changed
+          - not tag_batch_idem.interfaces[1].changed
+        fail_msg: "INTF-TAG-BATCH-2 FAILED: expected no change"
+        success_msg: "INTF-TAG-BATCH-2 PASSED: Idempotent"
+
+    - name: "[INTF-TAG-BATCH-3] Remove batch tags from both interfaces"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        interfaces:
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if }}"
+          - system_name: "{{ test_system_name }}"
+            interface_name: "{{ test_eth_if2 }}"
+        tags:
+          - "batch-tag-a"
+          - "batch-tag-b"
+        tag_state: absent
+        state: interface_tagged
+        auth_token: "{{ auth.token }}"
+      register: tag_batch_remove
+
+    - name: "[INTF-TAG-BATCH-3] Assert tags removed from both interfaces"
+      ansible.builtin.assert:
+        that:
+          - tag_batch_remove.changed
+          - tag_batch_remove.interfaces[0].changed
+          - tag_batch_remove.interfaces[1].changed
+          - tag_batch_remove.interfaces[0].interface_tags | length == 0
+          - tag_batch_remove.interfaces[1].interface_tags | length == 0
+        fail_msg: "INTF-TAG-BATCH-3 FAILED"
+        success_msg: "INTF-TAG-BATCH-3 PASSED: Tags removed from both interfaces"
+
+    # ════════════════════════════════════════════════════════════════
     #  FEATURE 4: LAG mode
     # ════════════════════════════════════════════════════════════════
 
@@ -716,6 +801,6 @@
         msg: >-
           All interface management tests PASSED:
           Feature 2 (admin_state): INTF-SHUT-1..4,
-          Feature 3 (tags): INTF-TAG-1..6,
+          Feature 3 (tags): INTF-TAG-1..6, INTF-TAG-BATCH-1..3,
           Feature 4 (lag_mode): LAG-1..4,
           Feature 1 (speed): SPEED-1..3

--- a/ansible_collections/juniper/apstra/tests/interface.yml
+++ b/ansible_collections/juniper/apstra/tests/interface.yml
@@ -1,0 +1,647 @@
+---
+# ── Test playbook for interface management features ────────────────
+#
+# Tests:
+#   Feature 1 (speed_updated)   : via interface_map module
+#   Feature 2 (interface_updated): admin up/down via blueprint module
+#   Feature 3 (interface_tagged) : tags add/remove via blueprint module
+#   Feature 4 (lag_updated)      : lag_mode change via blueprint module
+#
+# Prerequisites:
+#   - Apstra server reachable
+#   - L2 Virtual EVPN template available ("L2_Virtual_EVPN")
+#
+# Usage:
+#   ansible-playbook tests/interface.yml
+#   ansible-playbook tests/interface.yml -e template_id=L2_Virtual_EVPN
+
+- name: Test interface management
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    template_id: "{{ template | default('L2_Virtual_MLAG') }}"
+
+  tasks:
+    # ── Auth ──────────────────────────────────────────────────────
+    - name: Get local hostname
+      ansible.builtin.command: hostname
+      register: local_hostname
+      changed_when: false
+
+    - name: Set blueprint name fact
+      ansible.builtin.set_fact:
+        blueprint_name: "test_intf_{{ local_hostname.stdout }}"
+
+    - name: Connect to Apstra
+      juniper.apstra.authenticate:
+        logout: false
+      register: auth
+
+    # ── Setup: Cleanup any leftover blueprint ─────────────────────
+    - name: Find leftover interface test blueprint from prior runs
+      juniper.apstra.blueprint:
+        body:
+          label: "{{ blueprint_name }}"
+          design: "two_stage_l3clos"
+          init_type: "template_reference"
+          template_id: "{{ template_id }}"
+        lock_state: ignore
+        state: present
+        auth_token: "{{ auth.token }}"
+      register: bp_stale
+      ignore_errors: true
+
+    - name: Delete leftover interface test blueprint if found
+      juniper.apstra.blueprint:
+        id: "{{ bp_stale.id }}"
+        lock_state: ignore
+        state: absent
+        auth_token: "{{ auth.token }}"
+      when:
+        - bp_stale is success
+        - bp_stale.id is defined
+        - bp_stale.id.blueprint is defined
+        - bp_stale.id.blueprint | length > 0
+      ignore_errors: true
+
+    # ── Setup: Create test blueprint ──────────────────────────────
+    - name: "[SETUP] Create L2-EVPN test blueprint"
+      juniper.apstra.blueprint:
+        body:
+          label: "{{ blueprint_name }}"
+          design: "two_stage_l3clos"
+          init_type: "template_reference"
+          template_id: "{{ template_id }}"
+        lock_state: locked
+        auth_token: "{{ auth.token }}"
+      register: bp
+
+    - name: Set blueprint ID fact
+      ansible.builtin.set_fact:
+        bp_id: "{{ bp.id.blueprint }}"
+
+    # ── Setup: Assign interface maps so nodes are fully configured ─
+    - name: "[SETUP] Query leaf nodes"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        state: queried
+        query_type: nodes_by_role
+        roles:
+          - leaf
+          - spine
+        auth_token: "{{ auth.token }}"
+      register: bp_nodes
+
+    - name: "[SETUP] Extract leaf and spine node IDs"
+      ansible.builtin.set_fact:
+        leaf_ids: >-
+          {{ bp_nodes.nodes | dict2items
+            | selectattr('value.role', 'equalto', 'leaf')
+            | map(attribute='value.id') | list }}
+        spine_ids: >-
+          {{ bp_nodes.nodes | dict2items
+            | selectattr('value.role', 'equalto', 'spine')
+            | map(attribute='value.id') | list }}
+        leaf_labels: >-
+          {{ bp_nodes.nodes | dict2items
+            | selectattr('value.role', 'equalto', 'leaf')
+            | map(attribute='value.label') | list }}
+
+    - name: "[SETUP] Display leaf/spine node counts"
+      ansible.builtin.debug:
+        msg: "Found {{ leaf_ids | length }} leaf(s) and {{ spine_ids | length }} spine(s). Leaf labels: {{ leaf_labels }}"
+
+    - name: Fail if no leaf nodes found
+      ansible.builtin.fail:
+        msg: "No leaf nodes found in blueprint - cannot run interface tests"
+      when: leaf_ids | length == 0
+
+    - name: "[SETUP] Set test system name (first leaf)"
+      ansible.builtin.set_fact:
+        test_system_name: "{{ leaf_labels[0] }}"
+
+    # ── Setup: Get all design interface maps ──────────────────────
+    - name: "[SETUP] Get all design interface maps"
+      juniper.apstra.design:
+        id:
+          design_type: interface_map
+          name: all
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: all_imaps
+
+    - name: "[SETUP] Query leaf logical device"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        state: queried
+        query: >-
+          node('system', id='{{ leaf_ids[0] }}', name='sys')
+          .out('logical_device')
+          .node('logical_device', name='ld')
+        auth_token: "{{ auth.token }}"
+      register: leaf_ld_qe
+
+    - name: "[SETUP] Extract leaf logical device name"
+      ansible.builtin.set_fact:
+        leaf_ld_id: "{{ leaf_ld_qe.results[0]['ld']['label'] | regex_replace('_v\\d+$', '') }}"
+
+    - name: "[SETUP] Find leaf interface map"
+      ansible.builtin.set_fact:
+        leaf_imap_id: >-
+          {{ (all_imaps.design_items
+            | selectattr('logical_device_id', 'equalto', leaf_ld_id)
+            | list | first).id }}
+
+    - name: "[SETUP] Query spine logical device"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        state: queried
+        query: >-
+          node('system', id='{{ spine_ids[0] }}', name='sys')
+          .out('logical_device')
+          .node('logical_device', name='ld')
+        auth_token: "{{ auth.token }}"
+      register: spine_ld_qe
+
+    - name: "[SETUP] Extract spine logical device name"
+      ansible.builtin.set_fact:
+        spine_ld_id: "{{ spine_ld_qe.results[0]['ld']['label'] | regex_replace('_v\\d+$', '') }}"
+
+    - name: "[SETUP] Find spine interface map"
+      ansible.builtin.set_fact:
+        spine_imap_id: >-
+          {{ (all_imaps.design_items
+            | selectattr('logical_device_id', 'equalto', spine_ld_id)
+            | list | first).id }}
+
+    - name: "[SETUP] Assign interface maps to all nodes"
+      juniper.apstra.interface_map:
+        id:
+          blueprint: "{{ bp_id }}"
+        body:
+          assignments: >-
+            {{
+              dict(
+                leaf_ids | zip_longest([], fillvalue=leaf_imap_id) | list
+                + spine_ids | zip_longest([], fillvalue=spine_imap_id) | list
+              )
+            }}
+        auth_token: "{{ auth.token }}"
+        state: present
+      register: im_assign
+
+    # ── Setup: Discover test interfaces ───────────────────────────
+    - name: "[SETUP] Query ethernet interfaces on first leaf"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        state: queried
+        query: >-
+          node('system', label='{{ test_system_name }}', name='sys')
+          .out('hosted_interfaces')
+          .node('interface', if_type='ethernet', name='iface')
+        auth_token: "{{ auth.token }}"
+      register: eth_ifaces_qe
+
+    - name: "[SETUP] Query port_channel interfaces on first leaf"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        state: queried
+        query: >-
+          node('system', label='{{ test_system_name }}', name='sys')
+          .out('hosted_interfaces')
+          .node('interface', if_type='port_channel', name='iface')
+        auth_token: "{{ auth.token }}"
+      register: lag_ifaces_qe
+
+    - name: "[SETUP] Set test interface names"
+      ansible.builtin.set_fact:
+        test_eth_if: "{{ eth_ifaces_qe.results[0]['iface']['if_name'] }}"
+        test_lag_if: "{{ lag_ifaces_qe.results[0]['iface']['if_name'] }}"
+
+    - name: "[SETUP] Display test system and interfaces"
+      ansible.builtin.debug:
+        msg: >-
+          system={{ test_system_name }},
+          ethernet_if={{ test_eth_if }},
+          lag_if={{ test_lag_if }}
+
+    # ════════════════════════════════════════════════════════════════
+    #  FEATURE 2: Admin state (shut / no-shut)
+    # ════════════════════════════════════════════════════════════════
+
+    - name: "[INTF-SHUT-1] Shut down ethernet interface"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        admin_state: "down"
+        state: interface_updated
+        auth_token: "{{ auth.token }}"
+      register: shut_result
+
+    - name: "[INTF-SHUT-1] Display result"
+      ansible.builtin.debug:
+        var: shut_result
+
+    - name: "[INTF-SHUT-1] Assert changed and admin_down"
+      ansible.builtin.assert:
+        that:
+          - shut_result.changed
+          - shut_result.operation_state == "admin_down"
+        fail_msg: "INTF-SHUT-1 FAILED: expected changed=True and operation_state=admin_down"
+        success_msg: "INTF-SHUT-1 PASSED: Interface shut (admin_down)"
+
+    - name: "[INTF-SHUT-2] Shut same interface again (idempotent)"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        admin_state: "down"
+        state: interface_updated
+        auth_token: "{{ auth.token }}"
+      register: shut_idem_result
+
+    - name: "[INTF-SHUT-2] Assert no change"
+      ansible.builtin.assert:
+        that:
+          - not shut_idem_result.changed
+        fail_msg: "INTF-SHUT-2 FAILED: expected changed=False (idempotent)"
+        success_msg: "INTF-SHUT-2 PASSED: Idempotent shut"
+
+    - name: "[INTF-SHUT-3] Restore interface (no-shut)"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        admin_state: "up"
+        state: interface_updated
+        auth_token: "{{ auth.token }}"
+      register: noshut_result
+
+    - name: "[INTF-SHUT-3] Assert changed and up"
+      ansible.builtin.assert:
+        that:
+          - noshut_result.changed
+          - noshut_result.operation_state == "up"
+        fail_msg: "INTF-SHUT-3 FAILED: expected changed=True and operation_state=up"
+        success_msg: "INTF-SHUT-3 PASSED: Interface restored (up)"
+
+    - name: "[INTF-SHUT-4] No-shut again (idempotent)"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        admin_state: "up"
+        state: interface_updated
+        auth_token: "{{ auth.token }}"
+      register: noshut_idem_result
+
+    - name: "[INTF-SHUT-4] Assert no change"
+      ansible.builtin.assert:
+        that:
+          - not noshut_idem_result.changed
+        fail_msg: "INTF-SHUT-4 FAILED: expected changed=False (idempotent)"
+        success_msg: "INTF-SHUT-4 PASSED: Idempotent no-shut"
+
+    # ════════════════════════════════════════════════════════════════
+    #  FEATURE 3: Interface tags
+    # ════════════════════════════════════════════════════════════════
+
+    - name: "[INTF-TAG-1] Add tag to ethernet interface"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        tags:
+          - "test-intf-tag"
+        tag_state: present
+        state: interface_tagged
+        auth_token: "{{ auth.token }}"
+      register: tag_add_result
+
+    - name: "[INTF-TAG-1] Display result"
+      ansible.builtin.debug:
+        var: tag_add_result
+
+    - name: "[INTF-TAG-1] Assert changed and tag present"
+      ansible.builtin.assert:
+        that:
+          - tag_add_result.changed
+          - '"test-intf-tag" in tag_add_result.interface_tags'
+        fail_msg: "INTF-TAG-1 FAILED: expected changed=True with tag 'test-intf-tag'"
+        success_msg: "INTF-TAG-1 PASSED: Tag added"
+
+    - name: "[INTF-TAG-2] Add same tag again (idempotent)"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        tags:
+          - "test-intf-tag"
+        tag_state: present
+        state: interface_tagged
+        auth_token: "{{ auth.token }}"
+      register: tag_idem_result
+
+    - name: "[INTF-TAG-2] Assert no change"
+      ansible.builtin.assert:
+        that:
+          - not tag_idem_result.changed
+        fail_msg: "INTF-TAG-2 FAILED: expected changed=False (idempotent)"
+        success_msg: "INTF-TAG-2 PASSED: Idempotent tag add"
+
+    - name: "[INTF-TAG-3] Add second tag"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        tags:
+          - "test-intf-tag2"
+        tag_state: present
+        state: interface_tagged
+        auth_token: "{{ auth.token }}"
+      register: tag_add2_result
+
+    - name: "[INTF-TAG-3] Assert changed and both tags present"
+      ansible.builtin.assert:
+        that:
+          - tag_add2_result.changed
+          - '"test-intf-tag" in tag_add2_result.interface_tags'
+          - '"test-intf-tag2" in tag_add2_result.interface_tags'
+        fail_msg: "INTF-TAG-3 FAILED: expected changed=True with both tags present"
+        success_msg: "INTF-TAG-3 PASSED: Second tag added, first preserved"
+
+    - name: "[INTF-TAG-4] Remove first tag"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        tags:
+          - "test-intf-tag"
+        tag_state: absent
+        state: interface_tagged
+        auth_token: "{{ auth.token }}"
+      register: tag_remove_result
+
+    - name: "[INTF-TAG-4] Assert changed and tag removed"
+      ansible.builtin.assert:
+        that:
+          - tag_remove_result.changed
+          - '"test-intf-tag" not in tag_remove_result.interface_tags'
+          - '"test-intf-tag2" in tag_remove_result.interface_tags'
+        fail_msg: "INTF-TAG-4 FAILED: expected changed=True, test-intf-tag removed, test-intf-tag2 preserved"
+        success_msg: "INTF-TAG-4 PASSED: Tag removed, second tag preserved"
+
+    - name: "[INTF-TAG-5] Remove same tag again (idempotent)"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        tags:
+          - "test-intf-tag"
+        tag_state: absent
+        state: interface_tagged
+        auth_token: "{{ auth.token }}"
+      register: tag_remove_idem_result
+
+    - name: "[INTF-TAG-5] Assert no change"
+      ansible.builtin.assert:
+        that:
+          - not tag_remove_idem_result.changed
+        fail_msg: "INTF-TAG-5 FAILED: expected changed=False (idempotent)"
+        success_msg: "INTF-TAG-5 PASSED: Idempotent tag remove"
+
+    - name: "[INTF-TAG-6] Remove remaining tag"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_eth_if }}"
+        tags:
+          - "test-intf-tag2"
+        tag_state: absent
+        state: interface_tagged
+        auth_token: "{{ auth.token }}"
+      register: tag_cleanup_result
+
+    - name: "[INTF-TAG-6] Assert changed and no tags remaining"
+      ansible.builtin.assert:
+        that:
+          - tag_cleanup_result.changed
+          - tag_cleanup_result.interface_tags | length == 0
+        fail_msg: "INTF-TAG-6 FAILED: expected changed=True and empty tags"
+        success_msg: "INTF-TAG-6 PASSED: All tags cleared"
+
+    # ════════════════════════════════════════════════════════════════
+    #  FEATURE 4: LAG mode
+    # ════════════════════════════════════════════════════════════════
+
+    - name: "[LAG-1] Set lag_mode to lacp_passive on port_channel"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_lag_if }}"
+        lag_mode: "lacp_passive"
+        state: lag_updated
+        auth_token: "{{ auth.token }}"
+      register: lag_result
+
+    - name: "[LAG-1] Display result"
+      ansible.builtin.debug:
+        var: lag_result
+
+    - name: "[LAG-1] Assert changed and lag_mode set"
+      ansible.builtin.assert:
+        that:
+          - lag_result.changed
+          - lag_result.lag_mode == "lacp_passive"
+        fail_msg: "LAG-1 FAILED: expected changed=True and lag_mode=lacp_passive"
+        success_msg: "LAG-1 PASSED: lag_mode set to lacp_passive"
+
+    - name: "[LAG-2] Set same lag_mode again (idempotent)"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_lag_if }}"
+        lag_mode: "lacp_passive"
+        state: lag_updated
+        auth_token: "{{ auth.token }}"
+      register: lag_idem_result
+
+    - name: "[LAG-2] Assert no change"
+      ansible.builtin.assert:
+        that:
+          - not lag_idem_result.changed
+        fail_msg: "LAG-2 FAILED: expected changed=False (idempotent)"
+        success_msg: "LAG-2 PASSED: Idempotent lag_mode"
+
+    - name: "[LAG-3] Change lag_mode to static_lag"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_lag_if }}"
+        lag_mode: "static_lag"
+        state: lag_updated
+        auth_token: "{{ auth.token }}"
+      register: lag_change_result
+
+    - name: "[LAG-3] Assert changed and lag_mode updated"
+      ansible.builtin.assert:
+        that:
+          - lag_change_result.changed
+          - lag_change_result.lag_mode == "static_lag"
+        fail_msg: "LAG-3 FAILED: expected changed=True and lag_mode=static_lag"
+        success_msg: "LAG-3 PASSED: lag_mode changed to static_lag"
+
+    - name: "[LAG-4] Restore lag_mode to lacp_active"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        system_name: "{{ test_system_name }}"
+        interface_name: "{{ test_lag_if }}"
+        lag_mode: "lacp_active"
+        state: lag_updated
+        auth_token: "{{ auth.token }}"
+      register: lag_restore_result
+
+    - name: "[LAG-4] Assert changed and lag_mode restored"
+      ansible.builtin.assert:
+        that:
+          - lag_restore_result.changed
+          - lag_restore_result.lag_mode == "lacp_active"
+        fail_msg: "LAG-4 FAILED: expected changed=True and lag_mode=lacp_active"
+        success_msg: "LAG-4 PASSED: lag_mode restored to lacp_active"
+
+    # ════════════════════════════════════════════════════════════════
+    #  FEATURE 1: Interface speed (via interface_map module)
+    # ════════════════════════════════════════════════════════════════
+
+    - name: "[SPEED-1] Get current IM assignment to extract current speed"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        state: queried
+        query: >-
+          node('system', label='{{ test_system_name }}', name='sys')
+          .out('hosted_interfaces')
+          .node('interface', if_type='ethernet', name='iface')
+        auth_token: "{{ auth.token }}"
+      register: eth_ifaces_speed_qe
+
+    - name: "[SPEED-1] Discover speed of first ethernet interface via design IM"
+      juniper.apstra.design:
+        id:
+          design_type: interface_map
+          name: "{{ leaf_imap_id }}"
+        state: queried
+        auth_token: "{{ auth.token }}"
+      register: leaf_im_detail
+
+    - name: "[SPEED-1] Display leaf interface map details"
+      ansible.builtin.debug:
+        var: leaf_im_detail
+
+    - name: "[SPEED-1] Assign interface map with speed_updated (idempotent - same IM)"
+      juniper.apstra.interface_map:
+        id:
+          blueprint: "{{ bp_id }}"
+        body:
+          system_name: "{{ test_system_name }}"
+          interface_name: "{{ test_eth_if }}"
+          speed: "10G"
+        auth_token: "{{ auth.token }}"
+        state: speed_updated
+      register: speed_idem_result
+      ignore_errors: true
+
+    - name: "[SPEED-1] Display speed_updated result"
+      ansible.builtin.debug:
+        var: speed_idem_result
+
+    - name: "[SPEED-1] Assert no change when speed already matches"
+      ansible.builtin.assert:
+        that:
+          - not speed_idem_result.changed
+        fail_msg: "SPEED-1 FAILED: expected changed=False when speed already matches"
+        success_msg: "SPEED-1 PASSED: Idempotent speed_updated"
+      when: speed_idem_result is not failed
+
+    - name: "[SPEED-2] Test speed_updated with invalid system (error handling)"
+      juniper.apstra.interface_map:
+        id:
+          blueprint: "{{ bp_id }}"
+        body:
+          system_name: "nonexistent_system_xyz"
+          interface_name: "ge-0/0/0"
+          speed: "10G"
+        auth_token: "{{ auth.token }}"
+        state: speed_updated
+      register: speed_err_result
+      ignore_errors: true
+
+    - name: "[SPEED-2] Assert failed with appropriate error"
+      ansible.builtin.assert:
+        that:
+          - speed_err_result is failed
+          - "'nonexistent_system_xyz' in speed_err_result.msg"
+        fail_msg: "SPEED-2 FAILED: expected failure for nonexistent system"
+        success_msg: "SPEED-2 PASSED: Correctly failed for nonexistent system"
+
+    - name: "[SPEED-3] Test speed_updated with missing required param (error handling)"
+      juniper.apstra.interface_map:
+        id:
+          blueprint: "{{ bp_id }}"
+        body:
+          system_name: "{{ test_system_name }}"
+          speed: "10G"
+        auth_token: "{{ auth.token }}"
+        state: speed_updated
+      register: speed_missing_result
+      ignore_errors: true
+
+    - name: "[SPEED-3] Assert failed with appropriate error"
+      ansible.builtin.assert:
+        that:
+          - speed_missing_result is failed
+        fail_msg: "SPEED-3 FAILED: expected failure when interface_name missing"
+        success_msg: "SPEED-3 PASSED: Correctly failed when interface_name missing"
+
+    # ════════════════════════════════════════════════════════════════
+    #  Cleanup
+    # ════════════════════════════════════════════════════════════════
+
+    - name: "[CLEANUP] Delete test blueprint"
+      juniper.apstra.blueprint:
+        id:
+          blueprint: "{{ bp_id }}"
+        lock_state: ignore
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: bp_delete
+
+    - name: All interface management tests completed"
+      ansible.builtin.debug:
+        msg: >-
+          All interface management tests PASSED:
+          Feature 2 (admin_state): INTF-SHUT-1..4,
+          Feature 3 (tags): INTF-TAG-1..6,
+          Feature 4 (lag_mode): LAG-1..4,
+          Feature 1 (speed): SPEED-1..3


### PR DESCRIPTION
Feature 1 (speed_updated): interface_map.py - change interface speed via
  design catalog IM reassignment. Idempotent.

Feature 2 (interface_updated): blueprint.py - admin shut/no-shut via
  PATCH operation_state on interface nodes. Idempotent.

Feature 3 (interface_tagged): blueprint.py - add/remove tags on interface
  nodes via PATCH tags[]. Supports tag_state=present/absent. Idempotent.

Feature 4 (lag_updated): blueprint.py - set lag_mode on port_channel
  interface nodes. Idempotent.

New files:
  - plugins/module_utils/apstra/bp_interface.py: utility helpers
  - tests/interface.yml: 17 integration tests (all passing)

Makefile: added test-interface target