### PR TITLE
blueprint: remove extra : on description

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -94,7 +94,7 @@ options:
   rack_count:
     description:
       - Desired total number of racks of C(rack_type) to exist in the blueprint.
-      - Declarative/idempotent behavior: the module only adds missing racks until
+      - Declarative/idempotent behavior the module only adds missing racks until
         the desired total is reached.
       - Mutually exclusive with C(racks_to_add).
       - Only used when C(state=rack_added).
@@ -104,7 +104,7 @@ options:
   racks_to_add:
     description:
       - Number of racks to add in this run.
-      - Imperative/non-idempotent behavior (WebUI-style): each run adds this many
+      - Imperative/non-idempotent behavior (WebUI-style) each run adds this many
         racks regardless of current count.
       - Mutually exclusive with C(rack_count).
       - Only used when C(state=rack_added).


### PR DESCRIPTION
fix after last change

plugins/modules/blueprint.py:99:7: error: DOCUMENTATION: syntax error: could not find expected ':' (syntax)
plugins/modules/blueprint.py:99:7: unparsable-with-libyaml: DOCUMENTATION: while scanning a simple key could not find expected ':'