### PR TITLE
feat(BOT-367): Add tenant management to security_zone module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,7 +153,8 @@ install: build
 	test-interconnect_gateway \
 	test-cabling_map \
         test-virtual_infra_manager \
-        test-floating_ip
+        test-floating_ip \
+        test-tenant_management
 # Ignore warnings about localhost from ansible-playbook
 export ANSIBLE_LOCALHOST_WARNING=False
 export ANSIBLE_INVENTORY_UNPARSED_WARNING=False
@@ -255,6 +256,9 @@ test-virtual_infra_manager: install
 
 test-floating_ip: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/floating_ip.yml
+
+test-tenant_management: install
+	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/tenant_management.yml
 
 test-interconnect_gateway: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/interconnect_gateway.yml

--- a/ansible_collections/juniper/apstra/docs/security_zone_module.rst
+++ b/ansible_collections/juniper/apstra/docs/security_zone_module.rst
@@ -13,8 +13,8 @@
 
 .. Title
 
-juniper.apstra.security_zone module -- Manage security zones in Apstra
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+juniper.apstra.security_zone module -- Manage security zones and tenants in Apstra
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 .. Collection note
 
@@ -47,6 +47,9 @@ Synopsis
 .. Description
 
 - This module allows you to create, update, and delete security zones in Apstra.
+- Supports managing Tenant objects that group routing zones (security zones) under a label.
+- Supports bulk tenant operations via the ``tenants`` parameter.
+- Supports tenant-centric parameter aliases (``tenant_label``, ``tenant_description``) for VRF management.
 
 
 .. Aliases
@@ -178,7 +181,75 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Dictionary containing the security zone object details.
+      Dictionary containing the security zone object details. Tenant-centric aliases are supported (e.g. ``tenant_label`` maps to ``label``, ``tenant_description`` maps to ``vrf_description``).
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-tenant"></div>
+
+      .. _ansible_collections.juniper.apstra.security_zone_module__parameter-tenant:
+
+      .. rst-class:: ansible-option-title
+
+      **tenant**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-tenant" title="Permalink to this option"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      A single tenant definition for managing an Apstra Tenant object. A Tenant groups routing zones (security zones) under a label. Required key: ``label``. Optional key: ``routing_zones`` (list of security zone IDs or labels to assign). Mutually exclusive with ``body`` and ``tenants``.
+
+
+      .. raw:: html
+
+        </div>
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="parameter-tenants"></div>
+
+      .. _ansible_collections.juniper.apstra.security_zone_module__parameter-tenants:
+
+      .. rst-class:: ansible-option-title
+
+      **tenants**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#parameter-tenants" title="Permalink to this option"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      List of tenant definitions for bulk operations. Each entry is a dict with ``label`` and optional ``routing_zones``. A per-tenant ``state`` key (present/absent) can override the top-level ``state``. Mutually exclusive with ``body`` and ``tenant``.
 
 
       .. raw:: html
@@ -284,7 +355,7 @@ Parameters
 
         <div class="ansible-option-cell">
 
-      Desired state of the security zone.
+      Desired state of the security zone or tenant. Use ``list`` to enumerate all security zones and tenants.
 
 
       .. rst-class:: ansible-option-line
@@ -293,6 +364,7 @@ Parameters
 
       - :ansible-option-choices-entry-default:`"present"` :ansible-option-choices-default-mark:`← (default)`
       - :ansible-option-choices-entry:`"absent"`
+      - :ansible-option-choices-entry:`"list"`
 
 
       .. raw:: html
@@ -465,6 +537,58 @@ Examples
           blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
           security_zone: "AjAuUuVLylXCUgAqaQ"
         state: absent
+
+    - name: Create a security zone using tenant-centric aliases
+      juniper.apstra.security_zone:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        body:
+          tenant_label: "web-tier"
+          tenant_description: "Web tier VRF"
+          vni_id: 10001
+          sz_type: "evpn"
+        state: present
+
+    - name: List all security zones and tenants in a blueprint
+      juniper.apstra.security_zone:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        state: list
+
+    - name: Create a single tenant with routing zones
+      juniper.apstra.security_zone:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        tenant:
+          label: "production"
+          routing_zones:
+            - "web-tier"
+            - "app-tier"
+        state: present
+
+    - name: Delete a tenant
+      juniper.apstra.security_zone:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        tenant:
+          label: "production"
+        state: absent
+
+    - name: Bulk create/update/delete tenants
+      juniper.apstra.security_zone:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        tenants:
+          - label: "production"
+            routing_zones:
+              - "web-tier"
+              - "app-tier"
+          - label: "staging"
+            routing_zones:
+              - "db-tier"
+          - label: "old-tenant"
+            state: absent
+        state: present
 
 
 
@@ -776,6 +900,136 @@ Common return values are documented :ref:`here <common_return_values>`, the foll
       .. rst-class:: ansible-option-sample
 
       :ansible-option-sample-bold:`Sample:` :ansible-rv-sample-value:`["red", "blue"]`
+
+
+      .. raw:: html
+
+        </div>
+
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="return-security_zones"></div>
+
+      .. _ansible_collections.juniper.apstra.security_zone_module__return-security_zones:
+
+      .. rst-class:: ansible-option-title
+
+      **security_zones**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#return-security_zones" title="Permalink to this return value"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      List of all security zones in the blueprint.
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-returned-bold:`Returned:` when state is list
+
+
+      .. raw:: html
+
+        </div>
+
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="return-tenants"></div>
+
+      .. _ansible_collections.juniper.apstra.security_zone_module__return-tenants:
+
+      .. rst-class:: ansible-option-title
+
+      **tenants**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#return-tenants" title="Permalink to this return value"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`list` / :ansible-option-elements:`elements=dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      Results of bulk tenant operations, or list of all tenants when state is list.
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-returned-bold:`Returned:` when tenants/tenant parameter is used, or state is list
+
+      .. rst-class:: ansible-option-line
+      .. rst-class:: ansible-option-sample
+
+      :ansible-option-sample-bold:`Sample:` :ansible-rv-sample-value:`[{"id": "abc123", "label": "production", "application_node_ids": ["sz1", "sz2"]}]`
+
+
+      .. raw:: html
+
+        </div>
+
+
+  * - .. raw:: html
+
+        <div class="ansible-option-cell">
+        <div class="ansibleOptionAnchor" id="return-tenant"></div>
+
+      .. _ansible_collections.juniper.apstra.security_zone_module__return-tenant:
+
+      .. rst-class:: ansible-option-title
+
+      **tenant**
+
+      .. raw:: html
+
+        <a class="ansibleOptionLink" href="#return-tenant" title="Permalink to this return value"></a>
+
+      .. ansible-option-type-line::
+
+        :ansible-option-type:`dictionary`
+
+      .. raw:: html
+
+        </div>
+
+    - .. raw:: html
+
+        <div class="ansible-option-cell">
+
+      The tenant object details after single tenant create or update.
+
+
+      .. rst-class:: ansible-option-line
+
+      :ansible-option-returned-bold:`Returned:` when tenant parameter is used with state present
+
+      .. rst-class:: ansible-option-line
+      .. rst-class:: ansible-option-sample
+
+      :ansible-option-sample-bold:`Sample:` :ansible-rv-sample-value:`{"id": "abc123", "label": "production", "application_node_ids": ["sz1", "sz2"], "lowercased": "production"}`
 
 
       .. raw:: html

--- a/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_tenants.py
+++ b/ansible_collections/juniper/apstra/plugins/module_utils/apstra/bp_tenants.py
@@ -1,0 +1,202 @@
+# Copyright (c) 2024, Juniper Networks
+# BSD 3-Clause License
+
+"""Blueprint tenant utilities.
+
+Provides reusable helpers for managing tenants within an Apstra
+blueprint via ``raw_request``.  The SDK does not expose a dedicated
+tenant endpoint, so this module uses the REST API directly —
+following the same pattern as ``bp_configlets.py``.
+
+A **Tenant** in Apstra is a logical grouping of Routing Zones
+(Security Zones / VRFs).  Each tenant has a label and a list of
+security-zone IDs (``application_node_ids``) that belong to it.
+
+API endpoints::
+
+    GET    /api/blueprints/{bp_id}/tenants              → list
+    POST   /api/blueprints/{bp_id}/tenants              → create
+    GET    /api/blueprints/{bp_id}/tenants/{tenant_id}  → get
+    PUT    /api/blueprints/{bp_id}/tenants/{tenant_id}  → update (SZ linkage)
+    DELETE /api/blueprints/{bp_id}/tenants/{tenant_id}  → delete
+
+Create / PUT body::
+
+    {
+        "label": "my-tenant",
+        "application_node_ids": ["sz_id_1", "sz_id_2"]
+    }
+
+Note: The tenant *label* is immutable after creation.  PUT only
+updates ``application_node_ids``.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Collection operations
+# ──────────────────────────────────────────────────────────────────
+
+
+def list_tenants(client_factory, blueprint_id):
+    """List all tenants in a blueprint.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+
+    Returns:
+        list[dict]: List of tenant dicts.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/tenants")
+    if resp.status_code == 200:
+        data = resp.json()
+        return data.get("items", [])
+    return []
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Single resource operations
+# ──────────────────────────────────────────────────────────────────
+
+
+def get_tenant(client_factory, blueprint_id, tenant_id):
+    """Get a single tenant by ID.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        tenant_id: The tenant ID.
+
+    Returns:
+        dict or None: The tenant dict, or *None* if not found.
+    """
+    base = client_factory.get_base_client()
+    url = f"/blueprints/{blueprint_id}/tenants/{tenant_id}"
+    resp = base.raw_request(url)
+    if resp.status_code == 200:
+        return resp.json()
+    return None
+
+
+def create_tenant(client_factory, blueprint_id, label, security_zone_ids=None):
+    """Create a tenant in a blueprint.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        label: The tenant label.
+        security_zone_ids: Optional list of security-zone IDs to assign.
+
+    Returns:
+        dict: ``{"id": "<tenant_id>"}``
+
+    Raises:
+        Exception: If creation fails.
+    """
+    body = {"label": label}
+    if security_zone_ids:
+        body["application_node_ids"] = list(security_zone_ids)
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/tenants", "POST", data=body)
+    if resp.status_code in (200, 201):
+        return resp.json()
+    raise Exception(f"Failed to create tenant: {resp.status_code} {resp.text}")
+
+
+def update_tenant(client_factory, blueprint_id, tenant_id, security_zone_ids):
+    """Update a tenant's security-zone assignments.
+
+    The tenant label is immutable after creation; only
+    ``application_node_ids`` can be changed via PUT.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        tenant_id: The tenant ID.
+        security_zone_ids: List of security-zone IDs to assign.
+
+    Raises:
+        Exception: If the update fails.
+    """
+    body = {"application_node_ids": list(security_zone_ids)}
+    base = client_factory.get_base_client()
+    resp = base.raw_request(
+        f"/blueprints/{blueprint_id}/tenants/{tenant_id}", "PUT", data=body
+    )
+    if resp.status_code not in (200, 202, 204):
+        raise Exception(f"Failed to update tenant: {resp.status_code} {resp.text}")
+
+
+def delete_tenant(client_factory, blueprint_id, tenant_id):
+    """Delete a tenant from a blueprint.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        tenant_id: The tenant ID.
+
+    Raises:
+        Exception: If deletion fails.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/tenants/{tenant_id}", "DELETE")
+    if resp.status_code not in (200, 202, 204):
+        raise Exception(f"Failed to delete tenant: {resp.status_code} {resp.text}")
+
+
+# ──────────────────────────────────────────────────────────────────
+#  Convenience helpers
+# ──────────────────────────────────────────────────────────────────
+
+
+def find_tenant_by_label(client_factory, blueprint_id, label):
+    """Find a tenant by its label.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        label: The tenant label to search for.
+
+    Returns:
+        dict or None: The matching tenant dict, or *None*.
+    """
+    items = list_tenants(client_factory, blueprint_id)
+    for item in items:
+        if isinstance(item, dict) and item.get("label") == label:
+            return item
+    return None
+
+
+def resolve_security_zone_ids(client_factory, blueprint_id, references):
+    """Resolve a list of security-zone references to IDs.
+
+    Each reference can be a security-zone ID or label.  Labels are
+    resolved by listing all security zones and matching.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        references: List of security-zone IDs or labels.
+
+    Returns:
+        list[str]: List of resolved security-zone IDs.
+
+    Raises:
+        ValueError: If a reference cannot be resolved.
+    """
+    from ansible_collections.juniper.apstra.plugins.module_utils.apstra.name_resolution import (
+        resolve_security_zone_id,
+    )
+
+    resolved = []
+    for ref in references:
+        sz_id = resolve_security_zone_id(
+            client_factory, blueprint_id, ref, raise_on_missing=True
+        )
+        resolved.append(sz_id)
+    return resolved

--- a/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
@@ -14,7 +14,7 @@ module: security_zone
 
 short_description: Manage security zones (tenants/VRFs) and tenants in Apstra
 
-version_added: "0.1.0"
+version_added: "1.0.9"
 
 author:
   - "Edwin Jacques (@edwinpjacques)"

--- a/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
@@ -12,7 +12,7 @@ DOCUMENTATION = """
 ---
 module: security_zone
 
-short_description: Manage security zones in Apstra
+short_description: Manage security zones (tenants/VRFs) and tenants in Apstra
 
 version_added: "0.1.0"
 
@@ -21,6 +21,11 @@ author:
 
 description:
   - This module allows you to create, update, and delete security zones in Apstra.
+  - Security zones map to VRFs/tenants in Apstra.
+  - Supports tenant-centric parameter aliases for intuitive VRF management.
+  - Supports bulk tenant operations via the C(tenants) parameter.
+  - Supports managing actual Tenant objects (grouping of routing zones)
+    via the C(tenant) parameter.
 
 options:
   api_url:
@@ -57,6 +62,9 @@ options:
   body:
     description:
       - Dictionary containing the security zone object details.
+      - Tenant-centric aliases are supported and mapped to their
+        security zone equivalents (e.g. C(tenant_label) -> C(label),
+        C(tenant_description) -> C(vrf_description)).
     required: false
     type: dict
   tags:
@@ -64,12 +72,32 @@ options:
       - List of tags to apply to the security zone.
     type: list
     elements: str
+  tenant:
+    description:
+      - A single tenant definition for managing an Apstra Tenant object.
+      - A Tenant groups routing zones (security zones) under a label.
+      - Required keys C(label) and optional C(routing_zones) (list of
+        security zone IDs or labels to assign).
+      - Mutually exclusive with C(body) and C(tenants).
+    type: dict
+    required: false
+  tenants:
+    description:
+      - List of tenant definitions for bulk operations.
+      - Each entry is a dict with C(label) and optional C(routing_zones).
+      - A per-tenant C(state) key (present/absent) can override the
+        top-level C(state).
+      - Mutually exclusive with C(body) and C(tenant).
+    type: list
+    elements: dict
+    required: false
   state:
     description:
-      - Desired state of the security zone.
+      - Desired state of the security zone or tenant.
+      - Use C(list) to enumerate all security zones and tenants in the blueprint.
     required: false
     type: str
-    choices: ["present", "absent"]
+    choices: ["present", "absent", "list"]
     default: "present"
 """
 
@@ -93,6 +121,17 @@ EXAMPLES = """
       policy_type: "user_defined"
     state: present
 
+- name: Create a tenant using tenant-centric aliases
+  juniper.apstra.security_zone:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    body:
+      tenant_label: "web-tier"
+      tenant_description: "Web tier VRF"
+      vni_id: 10001
+      sz_type: "evpn"
+    state: present
+
 - name: Update a security zone (or update it if the label exists)
   juniper.apstra.security_zone:
     id:
@@ -108,6 +147,47 @@ EXAMPLES = """
     id:
       blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
       security_zone: "AjAuUuVLylXCUgAqaQ"
+    state: absent
+
+- name: List all security zones / tenants in a blueprint
+  juniper.apstra.security_zone:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    state: list
+
+- name: Bulk create/update tenants
+  juniper.apstra.security_zone:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    tenants:
+      - label: "production"
+        routing_zones:
+          - "web-tier"
+          - "app-tier"
+      - label: "staging"
+        routing_zones:
+          - "db-tier"
+      - label: "old-tenant"
+        state: absent
+    state: present
+
+- name: Create a single tenant with routing zones
+  juniper.apstra.security_zone:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    tenant:
+      label: "production"
+      routing_zones:
+        - "web-tier"
+        - "app-tier"
+    state: present
+
+- name: Delete a tenant
+  juniper.apstra.security_zone:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    tenant:
+      label: "production"
     state: absent
 """
 
@@ -152,11 +232,19 @@ security_zone:
       "import_policy": "all",
       "policy_type": "user_defined"
   }
+security_zones:
+  description: List of all security zones in the blueprint.
+  returned: when state is list
+  type: list
 tag_response:
   description: The response from applying tags to the security zone.
   type: list
   returned: when tags are applied
   sample: ["red", "blue"]
+tenants:
+  description: Results of bulk tenant operations or list of all tenants.
+  returned: when tenants/tenant parameter is used, or state is list
+  type: list
 msg:
   description: The output message that the module generates.
   type: str
@@ -180,6 +268,178 @@ from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_nodes imp
     patch_node,
     node_needs_update,
 )
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_tenants import (
+    list_tenants,
+    create_tenant,
+    update_tenant,
+    delete_tenant,
+    find_tenant_by_label,
+    resolve_security_zone_ids,
+)
+
+# Tenant-centric alias mapping: tenant param → security zone param
+TENANT_ALIASES = {
+    "tenant_label": "label",
+    "tenant_description": "vrf_description",
+}
+
+
+def _resolve_tenant_aliases(body):
+    """Translate tenant-centric parameter aliases to their SZ equivalents.
+
+    If both the alias and the canonical key are present, the canonical
+    key takes precedence and the alias is silently dropped.
+    """
+    if not body:
+        return body
+    for alias, canonical in TENANT_ALIASES.items():
+        if alias in body:
+            # Canonical key already present — drop the alias
+            if canonical not in body:
+                body[canonical] = body[alias]
+            del body[alias]
+    return body
+
+
+def _manage_single_security_zone(
+    client_factory, module, object_type, leaf_object_type, id, body, state, tags
+):
+    """Create, update, or delete a single security zone.
+
+    Returns a per-item result dict with keys: changed, id, msg, and
+    optionally response, changes, tag_response, security_zone, ip_assignments.
+    """
+    result = dict(changed=False)
+
+    # Resolve tenant aliases
+    body = _resolve_tenant_aliases(body)
+
+    # Pop custom fields that the Apstra API does not understand
+    interfaces_ip_assignments = None
+    sz_name = None
+    if body:
+        interfaces_ip_assignments = body.pop("interfaces_ip_assignments", None)
+        sz_name = body.pop("sz_name", None)
+        # Pop tags from body and merge with top-level tags parameter
+        body_tags = body.pop("tags", None)
+        if body_tags is not None:
+            if tags is not None:
+                tags = list(set(tags) | set(body_tags))
+            else:
+                tags = body_tags
+        if sz_name:
+            body.setdefault("label", sz_name)
+            if set(body.keys()) == {"label"}:
+                body = None
+        elif not body:
+            body = None
+
+    # Resolve security_zone name/label to ID if needed
+    if leaf_object_type in id and id[leaf_object_type]:
+        id[leaf_object_type] = resolve_security_zone_id(
+            client_factory,
+            id["blueprint"],
+            id[leaf_object_type],
+            raise_on_missing=True,
+        )
+
+    # Coerce integer fields that the API requires as int, not str
+    if body:
+        for int_field in ("vni_id", "vlan_id"):
+            if int_field in body and body[int_field] is not None:
+                body[int_field] = int(body[int_field])
+
+    # Validate the id
+    missing_id = client_factory.validate_id(object_type, id)
+    if len(missing_id) > 1 or (
+        len(missing_id) == 1 and state == "absent" and missing_id[0] != leaf_object_type
+    ):
+        raise ValueError(f"Invalid id: {id} for desired state of {state}.")
+    object_id = id.get(leaf_object_type, None)
+
+    # See if the object exists
+    current_object = None
+    lookup_label = (body or {}).get("label") or sz_name
+    if object_id is None:
+        if lookup_label:
+            id_found = resolve_security_zone_id(
+                client_factory,
+                id["blueprint"],
+                lookup_label,
+                raise_on_missing=(body is None),
+            )
+        else:
+            id_found = None
+
+        if id_found:
+            id[leaf_object_type] = id_found
+            current_object = client_factory.object_request(object_type, "get", id)
+    else:
+        current_object = client_factory.object_request(object_type, "get", id)
+
+    # Make the requested changes
+    if state == "present":
+        if current_object:
+            result["id"] = id
+            if body:
+                changes = {}
+                if client_factory.compare_and_update(current_object, body, changes):
+                    updated_object = client_factory.object_request(
+                        object_type, "patch", id, changes
+                    )
+                    result["changed"] = True
+                    if updated_object:
+                        result["response"] = updated_object
+                    result["changes"] = changes
+                    result["msg"] = f"{leaf_object_type} updated successfully"
+            else:
+                result["changed"] = False
+                result["msg"] = f"No changes specified for {leaf_object_type}"
+        else:
+            if body is None:
+                raise ValueError(f"Must specify 'body' to create a {leaf_object_type}")
+            obj = client_factory.object_request(object_type, "create", id, body)
+            object_id = obj["id"]
+            id[leaf_object_type] = object_id
+            result["id"] = id
+            result["changed"] = True
+            result["response"] = obj
+            result["msg"] = f"{leaf_object_type} created successfully"
+
+        # Apply tags if specified
+        if tags is not None:
+            result["tag_response"] = client_factory.update_tags(
+                id, leaf_object_type, tags
+            )
+
+        # Return the final object state
+        if current_object is not None:
+            result[leaf_object_type] = current_object
+        else:
+            result[leaf_object_type] = client_factory.object_request(
+                object_type=object_type, op="get", id=id, retry=10, retry_delay=3
+            )
+
+        # Apply interface IP assignments if specified
+        if interfaces_ip_assignments:
+            _apply_interface_ip_assignments(
+                client_factory,
+                id["blueprint"],
+                id[leaf_object_type],
+                interfaces_ip_assignments,
+                result,
+            )
+
+    if state == "absent":
+        if current_object:
+            client_factory.object_request(object_type, "delete", id)
+            result["changed"] = True
+            result["msg"] = f"{leaf_object_type} deleted successfully"
+        else:
+            result["changed"] = False
+            result["msg"] = f"{leaf_object_type} not found, nothing to delete"
+
+    return result
 
 
 def _apply_interface_ip_assignments(
@@ -237,14 +497,98 @@ def _apply_interface_ip_assignments(
     result["ip_assignments"] = ip_results
 
 
+def _manage_single_tenant(client_factory, blueprint_id, tenant_def, state):
+    """Create, update, or delete a single Apstra Tenant object.
+
+    A Tenant groups routing zones (security zones) under a label.
+
+    Args:
+        client_factory: An ``ApstraClientFactory`` instance.
+        blueprint_id: The blueprint UUID.
+        tenant_def: Dict with ``label`` and optional ``routing_zones``.
+        state: ``"present"`` or ``"absent"``.
+
+    Returns:
+        dict: Per-item result with ``changed``, ``msg``, etc.
+    """
+    result = dict(changed=False)
+    label = tenant_def.get("label")
+    if not label:
+        raise ValueError("Each tenant must have a 'label'")
+
+    routing_zone_refs = tenant_def.get("routing_zones", [])
+
+    # Resolve routing zone labels/IDs
+    sz_ids = []
+    if routing_zone_refs:
+        sz_ids = resolve_security_zone_ids(
+            client_factory, blueprint_id, routing_zone_refs
+        )
+
+    # Check if tenant already exists
+    existing = find_tenant_by_label(client_factory, blueprint_id, label)
+
+    if state == "present":
+        if existing:
+            tenant_id = existing["id"]
+            current_sz_ids = sorted(existing.get("application_node_ids", []))
+            desired_sz_ids = sorted(sz_ids)
+            if current_sz_ids != desired_sz_ids and routing_zone_refs:
+                update_tenant(client_factory, blueprint_id, tenant_id, sz_ids)
+                result["changed"] = True
+                result["msg"] = f"Tenant '{label}' updated"
+                result["changes"] = {
+                    "application_node_ids": {
+                        "old": current_sz_ids,
+                        "new": desired_sz_ids,
+                    }
+                }
+                # Return expected state (API may be eventually consistent)
+                result["tenant"] = {
+                    "id": tenant_id,
+                    "label": label,
+                    "application_node_ids": desired_sz_ids,
+                    "lowercased": label.lower(),
+                }
+            else:
+                result["msg"] = f"Tenant '{label}' already exists, no changes"
+                result["tenant"] = existing
+            result["id"] = tenant_id
+        else:
+            obj = create_tenant(client_factory, blueprint_id, label, sz_ids)
+            result["changed"] = True
+            result["id"] = obj["id"]
+            result["msg"] = f"Tenant '{label}' created"
+            result["tenant"] = {
+                "id": obj["id"],
+                "label": label,
+                "application_node_ids": sorted(sz_ids),
+                "lowercased": label.lower(),
+            }
+    elif state == "absent":
+        if existing:
+            delete_tenant(client_factory, blueprint_id, existing["id"])
+            result["changed"] = True
+            result["msg"] = f"Tenant '{label}' deleted"
+        else:
+            result["msg"] = f"Tenant '{label}' not found, nothing to delete"
+
+    return result
+
+
 def main():
     object_module_args = dict(
         id=dict(type="dict", required=True),
         body=dict(type="dict", required=False),
         state=dict(
-            type="str", required=False, choices=["present", "absent"], default="present"
+            type="str",
+            required=False,
+            choices=["present", "absent", "list"],
+            default="present",
         ),
         tags=dict(type="list", elements="str", required=False),
+        tenant=dict(type="dict", required=False),
+        tenants=dict(type="list", elements="dict", required=False),
     )
     client_module_args = apstra_client_module_args()
     module_args = client_module_args | object_module_args
@@ -252,7 +596,15 @@ def main():
     # values expected to get set: changed, blueprint, msg
     result = dict(changed=False)
 
-    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        mutually_exclusive=[
+            ("body", "tenants"),
+            ("body", "tenant"),
+            ("tenant", "tenants"),
+        ],
+    )
 
     try:
         # Instantiate the client factory
@@ -266,7 +618,64 @@ def main():
         body = module.params.get("body", None)
         state = module.params["state"]
         tags = module.params.get("tags", None)
+        tenant = module.params.get("tenant", None)
+        tenants = module.params.get("tenants", None)
 
+        # Resolve tenant aliases on the single-body path
+        body = _resolve_tenant_aliases(body)
+
+        # Resolve blueprint name to ID if needed
+        if "blueprint" in id:
+            id["blueprint"] = client_factory.resolve_blueprint_id(id["blueprint"])
+
+        # ── state=list: enumerate all security zones and tenants ─
+        if state == "list":
+            all_sz = client_factory.object_request(object_type, "get", id)
+            sz_list = []
+            if isinstance(all_sz, dict):
+                if "items" in all_sz:
+                    sz_list = all_sz["items"]
+                else:
+                    sz_list = list(all_sz.values())
+            elif isinstance(all_sz, list):
+                sz_list = all_sz
+            result["security_zones"] = sz_list
+            # Also list actual Tenant objects
+            result["tenants"] = list_tenants(client_factory, id["blueprint"])
+            result["msg"] = (
+                f"Found {len(sz_list)} security zone(s) and "
+                f"{len(result['tenants'])} tenant(s)"
+            )
+            module.exit_json(**result)
+            return
+
+        # ── Single tenant object management ──────────────────────
+        if tenant:
+            t_result = _manage_single_tenant(
+                client_factory, id["blueprint"], dict(tenant), state
+            )
+            result.update(t_result)
+            module.exit_json(**result)
+            return
+
+        # ── Bulk tenant object operations ────────────────────────
+        if tenants:
+            tenant_results = []
+            for tenant_def in tenants:
+                tenant_def = dict(tenant_def)  # copy to avoid mutating input
+                t_state = tenant_def.pop("state", state)
+                t_result = _manage_single_tenant(
+                    client_factory, id["blueprint"], tenant_def, t_state
+                )
+                if t_result.get("changed"):
+                    result["changed"] = True
+                tenant_results.append(t_result)
+            result["tenants"] = tenant_results
+            result["msg"] = f"Processed {len(tenant_results)} tenant(s)"
+            module.exit_json(**result)
+            return
+
+        # ── Single security zone operation (original path) ───────
         # Pop custom fields that the Apstra API does not understand
         interfaces_ip_assignments = None
         sz_name = None
@@ -292,10 +701,6 @@ def main():
                     body = None
             elif not body:
                 body = None
-
-        # Resolve blueprint name to ID if needed
-        if "blueprint" in id:
-            id["blueprint"] = client_factory.resolve_blueprint_id(id["blueprint"])
 
         # Resolve security_zone name/label to ID if needed
         if leaf_object_type in id and id[leaf_object_type]:
@@ -411,7 +816,7 @@ def main():
             raise ValueError(f"Cannot manage a {leaf_object_type} without a object id")
 
         if state == "absent":
-            # Delete the blueprint
+            # Delete the security zone
             client_factory.object_request(object_type, "delete", id)
             result["changed"] = True
             result["msg"] = f"{leaf_object_type} deleted successfully"

--- a/ansible_collections/juniper/apstra/tests/tenant_management.yml
+++ b/ansible_collections/juniper/apstra/tests/tenant_management.yml
@@ -1,0 +1,447 @@
+---
+# Integration test for BOT-367: Tenant management enhancements
+# Tests: actual Tenant objects (routing zone grouping), tenant aliases,
+#         bulk operations, state=list, idempotency, backward compatibility
+- name: Test tenant management (BOT-367)
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    # ── Setup ─────────────────────────────────────────────────
+    - name: Generate unique blueprint name
+      ansible.builtin.set_fact:
+        blueprint_name: "test_tenant_{{ lookup('pipe', 'python3 -c \"import uuid; print(str(uuid.uuid4())[:12])\"') }}"
+
+    - name: Connect to Apstra
+      juniper.apstra.authenticate:
+        logout: false
+      register: auth
+
+    - name: Create blueprint
+      juniper.apstra.blueprint:
+        body:
+          design: "two_stage_l3clos"
+          init_type: "template_reference"
+          template_id: "L2_Virtual_EVPN"
+          label: "{{ blueprint_name }}"
+        lock_state: "ignore"
+        auth_token: "{{ auth.token }}"
+      register: bp
+
+    - name: Show created blueprint
+      ansible.builtin.debug:
+        var: bp
+
+    # ── Create security zones (routing zones) as prerequisites ──
+    - name: Create web-tier security zone
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        body:
+          label: "web-tier"
+          vrf_name: "web_tier_vrf"
+          vrf_description: "Web tier VRF"
+          vni_id: 10001
+          sz_type: "evpn"
+        auth_token: "{{ auth.token }}"
+      register: sz_web
+
+    - name: Create app-tier security zone
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        body:
+          label: "app-tier"
+          vrf_name: "app_tier_vrf"
+          vrf_description: "App tier VRF"
+          vni_id: 10002
+          sz_type: "evpn"
+        auth_token: "{{ auth.token }}"
+      register: sz_app
+
+    - name: Create db-tier security zone
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        body:
+          label: "db-tier"
+          vrf_name: "db_tier_vrf"
+          vrf_description: "DB tier VRF"
+          vni_id: 10003
+          sz_type: "evpn"
+        auth_token: "{{ auth.token }}"
+      register: sz_db
+
+    - name: Assert security zones created
+      ansible.builtin.assert:
+        that:
+          - sz_web.changed == true
+          - sz_app.changed == true
+          - sz_db.changed == true
+        fail_msg: "Setup FAIL: security zones not created"
+        success_msg: "Setup PASS: security zones created"
+
+    # ──────────────────────────────────────────────────────────
+    # AC-1: Create a single Tenant using the tenant parameter
+    # ──────────────────────────────────────────────────────────
+    - name: Create a tenant grouping web and app routing zones
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenant:
+          label: "production"
+          routing_zones:
+            - "web-tier"
+            - "app-tier"
+        auth_token: "{{ auth.token }}"
+      register: tenant_create
+
+    - name: Show tenant create result
+      ansible.builtin.debug:
+        var: tenant_create
+
+    - name: Assert tenant was created
+      ansible.builtin.assert:
+        that:
+          - tenant_create.changed == true
+          - tenant_create.tenant.label == "production"
+          - tenant_create.tenant.application_node_ids | length == 2
+          - tenant_create.id is defined
+        fail_msg: "AC-1 FAIL: single tenant creation failed"
+        success_msg: "AC-1 PASS: single tenant created with routing zones"
+
+    # ── AC-4: Idempotent tenant create ───────────────────────
+    - name: Create same tenant again (idempotent)
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenant:
+          label: "production"
+          routing_zones:
+            - "web-tier"
+            - "app-tier"
+        auth_token: "{{ auth.token }}"
+      register: tenant_idem
+
+    - name: Assert idempotent create
+      ansible.builtin.assert:
+        that:
+          - tenant_idem.changed == false
+        fail_msg: "AC-4 FAIL: tenant create not idempotent"
+        success_msg: "AC-4 PASS: tenant create is idempotent"
+
+    # ── Update tenant routing zones ──────────────────────────
+    - name: Update tenant - add db-tier routing zone
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenant:
+          label: "production"
+          routing_zones:
+            - "web-tier"
+            - "app-tier"
+            - "db-tier"
+        auth_token: "{{ auth.token }}"
+      register: tenant_update
+
+    - name: Assert tenant updated
+      ansible.builtin.assert:
+        that:
+          - tenant_update.changed == true
+          - tenant_update.tenant.application_node_ids | length == 3
+        fail_msg: "AC-1 FAIL: tenant update failed"
+        success_msg: "AC-1 PASS: tenant routing zone update works"
+
+    # ── Idempotent update ────────────────────────────────────
+    - name: Update tenant with same routing zones (idempotent)
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenant:
+          label: "production"
+          routing_zones:
+            - "web-tier"
+            - "app-tier"
+            - "db-tier"
+        auth_token: "{{ auth.token }}"
+      register: tenant_update_idem
+
+    - name: Assert idempotent update
+      ansible.builtin.assert:
+        that:
+          - tenant_update_idem.changed == false
+        fail_msg: "AC-4 FAIL: tenant update not idempotent"
+        success_msg: "AC-4 PASS: tenant update is idempotent"
+
+    # ──────────────────────────────────────────────────────────
+    # state=list: enumerate security zones AND tenants
+    # ──────────────────────────────────────────────────────────
+    - name: List all security zones and tenants
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        state: list
+        auth_token: "{{ auth.token }}"
+      register: sz_list
+
+    - name: Show list result
+      ansible.builtin.debug:
+        var: sz_list
+
+    - name: Assert list returns both SZs and tenants
+      ansible.builtin.assert:
+        that:
+          - sz_list.security_zones | length >= 3
+          - sz_list.tenants | length >= 1
+          - sz_list.tenants | selectattr('label', 'equalto', 'production') | list | length == 1
+        fail_msg: "state=list FAIL: did not return expected data"
+        success_msg: "state=list PASS: enumerates SZs and tenants"
+
+    # ──────────────────────────────────────────────────────────
+    # AC-2: Bulk tenant operations
+    # ──────────────────────────────────────────────────────────
+    - name: Delete production tenant to free routing zones
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenant:
+          label: "production"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: pre_bulk_delete
+
+    - name: Bulk create tenants
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenants:
+          - label: "staging"
+            routing_zones:
+              - "web-tier"
+          - label: "development"
+            routing_zones:
+              - "db-tier"
+        auth_token: "{{ auth.token }}"
+      register: bulk_create
+
+    - name: Show bulk create result
+      ansible.builtin.debug:
+        var: bulk_create
+
+    - name: Assert bulk create worked
+      ansible.builtin.assert:
+        that:
+          - bulk_create.changed == true
+          - bulk_create.tenants | length == 2
+          - bulk_create.tenants[0].changed == true
+          - bulk_create.tenants[1].changed == true
+        fail_msg: "AC-2 FAIL: bulk tenant create did not work"
+        success_msg: "AC-2 PASS: bulk tenant create works"
+
+    # ── Bulk create idempotency ──────────────────────────────
+    - name: Bulk create same tenants again (idempotent)
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenants:
+          - label: "staging"
+            routing_zones:
+              - "web-tier"
+          - label: "development"
+            routing_zones:
+              - "db-tier"
+        auth_token: "{{ auth.token }}"
+      register: bulk_idem
+
+    - name: Assert bulk idempotent
+      ansible.builtin.assert:
+        that:
+          - bulk_idem.changed == false
+          - bulk_idem.tenants[0].changed == false
+          - bulk_idem.tenants[1].changed == false
+        fail_msg: "AC-2/AC-4 FAIL: bulk create not idempotent"
+        success_msg: "AC-2/AC-4 PASS: bulk create is idempotent"
+
+    # ── Bulk update tenant routing zones ─────────────────────
+    - name: Bulk update tenants - add app-tier to staging
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenants:
+          - label: "staging"
+            routing_zones:
+              - "web-tier"
+              - "app-tier"
+          - label: "development"
+            routing_zones:
+              - "db-tier"
+        auth_token: "{{ auth.token }}"
+      register: bulk_update
+
+    - name: Assert bulk update worked
+      ansible.builtin.assert:
+        that:
+          - bulk_update.changed == true
+          - bulk_update.tenants[0].changed == true
+        fail_msg: "AC-2 FAIL: bulk update did not work"
+        success_msg: "AC-2 PASS: bulk update works"
+
+    # ── Verify tenant count ──────────────────────────────────
+    - name: List all after bulk operations
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        state: list
+        auth_token: "{{ auth.token }}"
+      register: list_after_bulk
+
+    - name: Assert 2 tenants exist
+      ansible.builtin.assert:
+        that:
+          - list_after_bulk.tenants | length == 2
+        fail_msg: "List FAIL: expected 2 tenants"
+        success_msg: "List PASS: 2 tenants found"
+
+    # ── AC-2: Bulk tenant delete ─────────────────────────────
+    - name: Bulk delete tenants using per-tenant state
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenants:
+          - label: "staging"
+            state: absent
+          - label: "development"
+            state: absent
+        auth_token: "{{ auth.token }}"
+      register: bulk_delete
+
+    - name: Show bulk delete result
+      ansible.builtin.debug:
+        var: bulk_delete
+
+    - name: Assert bulk delete worked
+      ansible.builtin.assert:
+        that:
+          - bulk_delete.changed == true
+          - bulk_delete.tenants[0].changed == true
+          - bulk_delete.tenants[1].changed == true
+        fail_msg: "AC-2 FAIL: bulk delete did not work"
+        success_msg: "AC-2 PASS: bulk delete works"
+
+    # ── Bulk delete idempotency ──────────────────────────────
+    - name: Bulk delete same tenants again (idempotent)
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenants:
+          - label: "staging"
+            state: absent
+          - label: "development"
+            state: absent
+        auth_token: "{{ auth.token }}"
+      register: bulk_delete_idem
+
+    - name: Assert bulk delete idempotent
+      ansible.builtin.assert:
+        that:
+          - bulk_delete_idem.changed == false
+          - bulk_delete_idem.tenants[0].changed == false
+          - bulk_delete_idem.tenants[1].changed == false
+        fail_msg: "AC-2/AC-4 FAIL: bulk delete not idempotent"
+        success_msg: "AC-2/AC-4 PASS: bulk delete is idempotent"
+
+    # ──────────────────────────────────────────────────────────
+    # AC-3: Backward compatibility — original SZ params still work
+    # ──────────────────────────────────────────────────────────
+    - name: Create SZ using tenant_label alias (backward compat)
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        body:
+          tenant_label: "alias-test"
+          tenant_description: "Alias backward compat"
+          vrf_name: "alias_test_vrf"
+          vni_id: 10010
+          sz_type: "evpn"
+        auth_token: "{{ auth.token }}"
+      register: alias_sz
+
+    - name: Assert backward compatibility
+      ansible.builtin.assert:
+        that:
+          - alias_sz.changed == true
+          - alias_sz.security_zone.label == "alias-test"
+          - alias_sz.security_zone.vrf_description == "Alias backward compat"
+        fail_msg: "AC-3 FAIL: backward compatibility broken"
+        success_msg: "AC-3 PASS: tenant aliases still work for SZ creation"
+
+    # ── Single tenant delete ─────────────────────────────────
+    - name: Create a tenant to test single delete
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenant:
+          label: "to-delete"
+          routing_zones:
+            - "web-tier"
+        auth_token: "{{ auth.token }}"
+      register: td_create
+
+    - name: Delete the to-delete tenant
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenant:
+          label: "to-delete"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: tenant_delete
+
+    - name: Assert tenant deleted
+      ansible.builtin.assert:
+        that:
+          - tenant_delete.changed == true
+        fail_msg: "Delete FAIL: tenant deletion failed"
+        success_msg: "Delete PASS: tenant deleted"
+
+    # ── Delete idempotency ───────────────────────────────────
+    - name: Delete same tenant again (idempotent)
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        tenant:
+          label: "to-delete"
+        state: absent
+        auth_token: "{{ auth.token }}"
+      register: tenant_delete_idem
+
+    - name: Assert delete idempotent
+      ansible.builtin.assert:
+        that:
+          - tenant_delete_idem.changed == false
+        fail_msg: "AC-4 FAIL: tenant delete not idempotent"
+        success_msg: "AC-4 PASS: tenant delete is idempotent"
+
+    # ── Final list — verify clean state ──────────────────────
+    - name: Final list
+      juniper.apstra.security_zone:
+        id: "{{ bp.id }}"
+        state: list
+        auth_token: "{{ auth.token }}"
+      register: final_list
+
+    - name: Assert no tenants remain
+      ansible.builtin.assert:
+        that:
+          - final_list.tenants | length == 0
+        fail_msg: "Cleanup FAIL: tenants still exist"
+        success_msg: "Cleanup PASS: all tenants removed"
+
+    # ── Teardown ─────────────────────────────────────────────
+    - name: Unlock the blueprint
+      juniper.apstra.blueprint:
+        id: "{{ bp.id }}"
+        lock_state: "unlocked"
+        auth_token: "{{ auth.token }}"
+
+    - name: Delete blueprint
+      juniper.apstra.blueprint:
+        id: "{{ bp.id }}"
+        state: absent
+        auth_token: "{{ auth.token }}"
+
+    - name: Logout of Apstra
+      juniper.apstra.authenticate:
+        logout: true
+        auth_token: "{{ auth.token }}"
+
+    - name: Final summary
+      ansible.builtin.debug:
+        msg: >
+          BOT-367 Acceptance Criteria Results:
+          AC-1 Tenant-centric naming (actual Tenant objects): PASS
+          AC-2 Bulk tenant operations: PASS
+          AC-3 Backward compatibility: PASS
+          AC-4 Idempotency: PASS
+          AC-5 Integration test playbook: PASS (this file)


### PR DESCRIPTION
## Summary

Implements **BOT-367: Blueprint Enhancement - Tenant management** by adding CRUD operations for Apstra Tenant objects to the `security_zone` module.

Tenants are a distinct entity in Apstra that group routing zones (security zones) under a named label, visible in the Apstra UI under **Policies > Tenants**.

## Changes

### New file: `plugins/module_utils/apstra/bp_tenants.py`
- Utility module for Tenant CRUD via `raw_request` (Tenant API is not exposed by the SDK)
- Functions: `list_tenants`, `get_tenant`, `create_tenant`, `update_tenant`, `delete_tenant`, `find_tenant_by_label`, `resolve_security_zone_ids`

### Modified: `plugins/modules/security_zone.py`
- **`tenant`** parameter (dict) — manage a single Tenant object with `label` and optional `routing_zones`
- **`tenants`** parameter (list of dicts) — bulk Tenant operations with per-item `state` override
- **`state=list`** — now returns both `security_zones` and `tenants` lists
- Routing zone references can be labels or IDs
- Full idempotency for create, update, and delete
- Mutually exclusive with `body` parameter to maintain backward compatibility

### New file: `tests/tenant_management.yml`
- 48-task integration test playbook covering all acceptance criteria

## Acceptance Criteria

| AC | Description | Status |
|----|-------------|--------|
| AC-1 | Single tenant create/update with routing zones | ✅ PASS |
| AC-2 | Bulk tenant create/update/delete | ✅ PASS |
| AC-3 | Backward compatibility (tenant_label alias) | ✅ PASS |
| AC-4 | Idempotency (create, update, delete) | ✅ PASS |
| AC-5 | Integration test playbook | ✅ PASS |

## Testing

- `tenant_management.yml`: **48/48 tasks passed** (0 failures)
- `security_zone.yml`: **35/35 tasks passed** (backward compatibility verified)

## API Details

```
POST   /api/blueprints/{bp_id}/tenants          → create tenant
GET    /api/blueprints/{bp_id}/tenants           → list tenants
GET    /api/blueprints/{bp_id}/tenants/{tid}     → get tenant
PUT    /api/blueprints/{bp_id}/tenants/{tid}     → update (application_node_ids only, label is immutable)
DELETE /api/blueprints/{bp_id}/tenants/{tid}     → delete tenant
```

Resolves: BOT-367