### PR TITLE
feat(BOT-369): Add blueprint_health module for anomalies and build errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,8 @@ install: build
 	test-interconnect_gateway \
 	test-cabling_map \
         test-virtual_infra_manager \
-        test-floating_ip
+        test-floating_ip \
+        test-blueprint_health
 # Ignore warnings about localhost from ansible-playbook
 export ANSIBLE_LOCALHOST_WARNING=False
 export ANSIBLE_INVENTORY_UNPARSED_WARNING=False
@@ -260,6 +261,9 @@ test-virtual_infra_manager: install
 
 test-floating_ip: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/floating_ip.yml
+
+test-blueprint_health: install
+	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/blueprint_health.yml
 
 test-interconnect_gateway: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/interconnect_gateway.yml

--- a/ansible_collections/juniper/apstra/docs/blueprint_health_module.rst
+++ b/ansible_collections/juniper/apstra/docs/blueprint_health_module.rst
@@ -138,6 +138,28 @@ Examples
         scope: anomalies
         severity: critical
 
+    - name: Collect anomalies for a specific node
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        scope: anomalies
+        node_filter: "leaf1"
+
+    - name: Filter anomalies by type
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        scope: anomalies
+        anomaly_type: "cabling"
+
+    - name: Filter anomalies by type for a specific node
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        scope: anomalies
+        node_filter: "leaf1"
+        anomaly_type: "cabling"
+
     - name: Collect build errors only
       juniper.apstra.blueprint_health:
         id:

--- a/ansible_collections/juniper/apstra/docs/blueprint_health_module.rst
+++ b/ansible_collections/juniper/apstra/docs/blueprint_health_module.rst
@@ -1,0 +1,151 @@
+.. Document meta
+
+:orphan:
+
+.. |antsibull-internal-nbsp| unicode:: 0xA0
+    :trim:
+
+.. Anchors
+
+.. _ansible_collections.juniper.apstra.blueprint_health_module:
+
+.. Title
+
+juniper.apstra.blueprint_health module -- Collect anomalies and build errors from an Apstra blueprint
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This module is part of the `juniper.apstra collection <https://galaxy.ansible.com/ui/repo/published/juniper/apstra/>`_.
+
+    It is not included in ``ansible-core``.
+    To check whether it is installed, run :code:`ansible-galaxy collection list`.
+
+    To install it, use: :code:`ansible-galaxy collection install juniper.apstra`.
+
+    To use it in a playbook, specify: :code:`juniper.apstra.blueprint_health`.
+
+.. version_added
+
+.. rst-class:: ansible-version-added
+
+New in juniper.apstra 1.0.9
+
+.. contents::
+   :local:
+   :depth: 1
+
+
+Synopsis
+--------
+
+.. Description
+
+- This module collects anomalies and build errors/warnings from an Apstra blueprint as structured data for monitoring, alerting, and reporting.
+- Anomalies are retrieved via ``GET /api/blueprints/{id}/anomalies``.
+- Build errors are retrieved via ``GET /api/blueprints/{id}/errors``.
+- Results can be filtered by scope, severity, anomaly type, and node.
+
+
+Parameters
+----------
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Parameter
+    - Comments
+
+  * - **api_url** (string)
+    - The URL used to access the Apstra API.
+
+  * - **auth_token** (string)
+    - The authentication token to use if already authenticated.
+
+  * - **id** (dictionary, **required**)
+    - Dictionary containing the blueprint identifier. Must include a ``blueprint`` key with the blueprint ID or label.
+
+  * - **scope** (string)
+    - The type of health data to collect. Choices: ``anomalies``, ``errors``, ``all``. Default: ``all``.
+
+  * - **severity** (string)
+    - Filter results by severity level. Choices: ``critical``, ``warning``, ``info``.
+
+  * - **node_filter** (string)
+    - Filter anomalies by system/node name or ID.
+
+  * - **anomaly_type** (string)
+    - Filter anomalies by anomaly type (e.g. ``cabling``, ``config``, ``bgp``, ``route``).
+
+  * - **username** (string)
+    - The username for authentication.
+
+  * - **password** (string)
+    - The password for authentication.
+
+  * - **verify_certificates** (boolean)
+    - If set to false, SSL certificates will not be verified. Default: ``true``.
+
+
+Return Values
+-------------
+
+.. list-table::
+  :width: 100%
+  :widths: auto
+  :header-rows: 1
+
+  * - Key
+    - Description
+
+  * - **changed** (boolean)
+    - Always false since this is a read-only module.
+
+  * - **anomalies** (dictionary)
+    - Anomaly data from the blueprint. Returned when scope is ``anomalies`` or ``all``.
+
+  * - **errors** (dictionary)
+    - Build errors and warnings from the blueprint. Returned when scope is ``errors`` or ``all``.
+
+  * - **msg** (string)
+    - Summary message with anomaly and error counts.
+
+
+Examples
+--------
+
+.. code-block:: yaml
+
+    - name: Collect all health data from a blueprint
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+      register: health
+
+    - name: Collect anomalies only
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "my-blueprint-label"
+        scope: anomalies
+
+    - name: Collect only critical anomalies
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        scope: anomalies
+        severity: critical
+
+    - name: Collect build errors only
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        scope: errors
+
+
+Authors
+-------
+
+- Prabhanjan KV (@kvp_jnpr)

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint_health.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint_health.py
@@ -1,0 +1,314 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024, Juniper Networks
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: blueprint_health
+short_description: Collect anomalies and build errors from an Apstra blueprint
+version_added: "1.0.9"
+author:
+  - "Prabhanjan KV (@kvp_jnpr)"
+description:
+  - This module collects anomalies and build errors/warnings from an Apstra
+    blueprint as structured data for monitoring, alerting, and reporting.
+  - Anomalies are retrieved via C(GET /api/blueprints/{id}/anomalies).
+  - Build errors are retrieved via C(GET /api/blueprints/{id}/errors).
+  - Results can be filtered by scope, severity, anomaly type, and node.
+options:
+  api_url:
+    description:
+      - The URL used to access the Apstra api.
+    type: str
+    required: false
+  verify_certificates:
+    description:
+      - If set to false, SSL certificates will not be verified.
+    type: bool
+    required: false
+    default: True
+  username:
+    description:
+      - The username for authentication.
+    type: str
+    required: false
+  password:
+    description:
+      - The password for authentication.
+    type: str
+    required: false
+  auth_token:
+    description:
+      - The authentication token to use if already authenticated.
+    type: str
+    required: false
+  id:
+    description:
+      - Dictionary containing the blueprint identifier.
+      - Must include a C(blueprint) key with the blueprint ID or label.
+    required: true
+    type: dict
+  scope:
+    description:
+      - The type of health data to collect.
+      - C(anomalies) collects blueprint anomalies only.
+      - C(errors) collects build errors and warnings only.
+      - C(all) collects both anomalies and build errors.
+    required: false
+    type: str
+    choices: ["anomalies", "errors", "all"]
+    default: "all"
+  severity:
+    description:
+      - Filter results by severity level.
+      - Only applies to anomalies.
+    required: false
+    type: str
+    choices: ["critical", "warning", "info"]
+  node_filter:
+    description:
+      - Filter anomalies by system/node name or ID.
+    required: false
+    type: str
+  anomaly_type:
+    description:
+      - Filter anomalies by anomaly type (e.g. C(cabling), C(config),
+        C(interface), C(bgp), C(route), C(arp), C(mac), C(series),
+        C(streaming), C(hostname), C(liveness), C(deployment)).
+    required: false
+    type: str
+"""
+
+EXAMPLES = """
+- name: Collect all health data from a blueprint
+  juniper.apstra.blueprint_health:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+  register: health
+
+- name: Collect anomalies only
+  juniper.apstra.blueprint_health:
+    id:
+      blueprint: "my-blueprint-label"
+    scope: anomalies
+  register: anomalies
+
+- name: Collect only critical anomalies
+  juniper.apstra.blueprint_health:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    scope: anomalies
+    severity: critical
+  register: critical_anomalies
+
+- name: Collect anomalies for a specific node
+  juniper.apstra.blueprint_health:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    scope: anomalies
+    node_filter: "leaf1"
+  register: node_anomalies
+
+- name: Collect build errors only
+  juniper.apstra.blueprint_health:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    scope: errors
+  register: build_errors
+
+- name: Filter anomalies by type
+  juniper.apstra.blueprint_health:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    scope: anomalies
+    anomaly_type: "cabling"
+  register: cabling_anomalies
+"""
+
+RETURN = """
+changed:
+  description: Always false since this is a read-only module.
+  type: bool
+  returned: always
+  sample: false
+anomalies:
+  description: Anomaly data from the blueprint.
+  type: dict
+  returned: when scope is 'anomalies' or 'all'
+  sample:
+    count: 5
+    items:
+      - type: "cabling"
+        severity: "error"
+        node: "leaf1"
+        message: "Interface mismatch detected"
+errors:
+  description: Build errors and warnings from the blueprint.
+  type: dict
+  returned: when scope is 'errors' or 'all'
+  sample:
+    errors_count: 2
+    warnings_count: 1
+msg:
+  description: The output message that the module generates.
+  type: str
+  returned: always
+"""
+
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.bp_dci import (
+    get_blueprint_errors,
+)
+
+
+def _get_anomalies(client_factory, blueprint_id):
+    """Retrieve anomalies for a blueprint via raw API call.
+
+    Calls GET /api/blueprints/{bp_id}/anomalies.
+
+    Args:
+        client_factory: An ApstraClientFactory instance.
+        blueprint_id: The blueprint UUID.
+
+    Returns:
+        dict: The anomalies payload with 'items' list and 'count'.
+    """
+    base = client_factory.get_base_client()
+    resp = base.raw_request(f"/blueprints/{blueprint_id}/anomalies")
+    if resp.status_code == 200:
+        return resp.json()
+    return {"items": [], "count": 0}
+
+
+def _filter_anomalies(
+    anomalies_data, severity=None, node_filter=None, anomaly_type=None
+):
+    """Filter anomalies by severity, node, and/or type.
+
+    Args:
+        anomalies_data: Raw anomalies response dict.
+        severity: Optional severity filter.
+        node_filter: Optional node name/ID filter.
+        anomaly_type: Optional anomaly type filter.
+
+    Returns:
+        dict: Filtered anomalies with updated count.
+    """
+    items = anomalies_data.get("items", [])
+
+    if severity:
+        items = [a for a in items if a.get("severity", "").lower() == severity.lower()]
+
+    if node_filter:
+        node_lower = node_filter.lower()
+        items = [
+            a
+            for a in items
+            if node_lower in str(a.get("identity", {}).get("system_id", "")).lower()
+            or node_lower in str(a.get("identity", {}).get("hostname", "")).lower()
+            or node_lower in str(a.get("identity", {}).get("label", "")).lower()
+            or node_lower in str(a.get("expected", "")).lower()
+            or node_lower in str(a.get("actual", "")).lower()
+            or node_lower in str(a.get("role", "")).lower()
+        ]
+
+    if anomaly_type:
+        type_lower = anomaly_type.lower()
+        items = [
+            a
+            for a in items
+            if type_lower in str(a.get("anomaly_type", "")).lower()
+            or type_lower in str(a.get("type", "")).lower()
+        ]
+
+    return {
+        "count": len(items),
+        "items": items,
+    }
+
+
+def main():
+    object_module_args = dict(
+        id=dict(type="dict", required=True),
+        scope=dict(
+            type="str",
+            required=False,
+            choices=["anomalies", "errors", "all"],
+            default="all",
+        ),
+        severity=dict(
+            type="str",
+            required=False,
+            choices=["critical", "warning", "info"],
+        ),
+        node_filter=dict(type="str", required=False),
+        anomaly_type=dict(type="str", required=False),
+    )
+    client_module_args = apstra_client_module_args()
+    module_args = client_module_args | object_module_args
+
+    result = dict(changed=False)
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    try:
+        client_factory = ApstraClientFactory.from_params(module)
+
+        id_param = module.params["id"]
+        scope = module.params["scope"]
+        severity = module.params.get("severity")
+        node_filter = module.params.get("node_filter")
+        anomaly_type = module.params.get("anomaly_type")
+
+        if "blueprint" not in id_param:
+            raise ValueError("The 'id' parameter must include a 'blueprint' key.")
+
+        blueprint_id = client_factory.resolve_blueprint_id(id_param["blueprint"])
+
+        # Collect anomalies
+        if scope in ("anomalies", "all"):
+            raw_anomalies = _get_anomalies(client_factory, blueprint_id)
+            result["anomalies"] = _filter_anomalies(
+                raw_anomalies,
+                severity=severity,
+                node_filter=node_filter,
+                anomaly_type=anomaly_type,
+            )
+
+        # Collect build errors
+        if scope in ("errors", "all"):
+            result["errors"] = get_blueprint_errors(client_factory, blueprint_id)
+
+        # Build summary message
+        parts = []
+        if "anomalies" in result:
+            parts.append(f"{result['anomalies']['count']} anomalies")
+        if "errors" in result:
+            ec = result["errors"].get("errors_count", 0)
+            wc = result["errors"].get("warnings_count", 0)
+            parts.append(f"{ec} errors, {wc} warnings")
+        result["msg"] = f"Blueprint health: {'; '.join(parts)}"
+
+    except Exception as e:
+        tb = traceback.format_exc()
+        module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
+        module.fail_json(msg=str(e), **result)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint_health.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint_health.py
@@ -129,6 +129,15 @@ EXAMPLES = """
     scope: anomalies
     anomaly_type: "cabling"
   register: cabling_anomalies
+
+- name: Filter anomalies by type for a specific node
+  juniper.apstra.blueprint_health:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    scope: anomalies
+    node_filter: "leaf1"
+    anomaly_type: "cabling"
+  register: leaf1_cabling_anomalies
 """
 
 RETURN = """
@@ -213,25 +222,46 @@ def _filter_anomalies(
 
     if node_filter:
         node_lower = node_filter.lower()
-        items = [
-            a
-            for a in items
-            if node_lower in str(a.get("identity", {}).get("system_id", "")).lower()
-            or node_lower in str(a.get("identity", {}).get("hostname", "")).lower()
-            or node_lower in str(a.get("identity", {}).get("label", "")).lower()
-            or node_lower in str(a.get("expected", "")).lower()
-            or node_lower in str(a.get("actual", "")).lower()
-            or node_lower in str(a.get("role", "")).lower()
-        ]
+
+        def _node_matches(anomaly):
+            identity = anomaly.get("identity") or {}
+            node_candidates = [
+                identity.get("system_id", ""),
+                identity.get("hostname", ""),
+                identity.get("label", ""),
+                anomaly.get("node", ""),
+                anomaly.get("node_id", ""),
+                anomaly.get("node_label", ""),
+                anomaly.get("role", ""),
+            ]
+
+            return any(
+                node_lower in str(value).lower() for value in node_candidates
+            ) or (
+                node_lower in str(anomaly.get("expected", "")).lower()
+                or node_lower in str(anomaly.get("actual", "")).lower()
+            )
+
+        items = [a for a in items if _node_matches(a)]
 
     if anomaly_type:
         type_lower = anomaly_type.lower()
-        items = [
-            a
-            for a in items
-            if type_lower in str(a.get("anomaly_type", "")).lower()
-            or type_lower in str(a.get("type", "")).lower()
-        ]
+
+        def _type_matches(anomaly):
+            type_candidates = [
+                anomaly.get("anomaly_type", ""),
+                anomaly.get("type", ""),
+                anomaly.get("anomaly_kind", ""),
+                anomaly.get("kind", ""),
+                anomaly.get("category", ""),
+            ]
+            anomaly_types = anomaly.get("anomaly_types", [])
+
+            return any(
+                type_lower in str(value).lower() for value in type_candidates
+            ) or any(type_lower in str(value).lower() for value in anomaly_types)
+
+        items = [a for a in items if _type_matches(a)]
 
     return {
         "count": len(items),

--- a/ansible_collections/juniper/apstra/tests/blueprint_health.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint_health.yml
@@ -1,0 +1,155 @@
+---
+- name: Test blueprint_health module
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  tasks:
+    - name: Get local hostname
+      ansible.builtin.command: hostname
+      register: local_hostname
+      changed_when: false
+
+    - name: Set blueprint name fact
+      ansible.builtin.set_fact:
+        blueprint_name: "test_bp_health_{{ local_hostname.stdout }}"
+
+    - name: Connect to Apstra
+      juniper.apstra.authenticate:
+        logout: false
+      register: auth
+
+    # ── Setup: create a test blueprint ──────────────────────────────────────
+    - name: Create test blueprint
+      juniper.apstra.blueprint:
+        body:
+          label: "{{ blueprint_name }}"
+          design: "freeform"
+        lock_state: "ignore"
+        auth_token: "{{ auth.token }}"
+      register: bp
+
+    - name: Show created blueprint
+      ansible.builtin.debug:
+        var: bp
+
+    # ── Test: Collect all health data (default scope) ───────────────────────
+    - name: Collect all health data
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        auth_token: "{{ auth.token }}"
+      register: health_all
+
+    - name: Show all health data
+      ansible.builtin.debug:
+        var: health_all
+
+    - name: Assert all health data returned
+      ansible.builtin.assert:
+        that:
+          - not health_all.changed
+          - health_all.anomalies is defined
+          - health_all.errors is defined
+          - health_all.anomalies.count is defined
+          - health_all.msg is defined
+
+    # ── Test: Collect anomalies only ────────────────────────────────────────
+    - name: Collect anomalies only
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        scope: anomalies
+        auth_token: "{{ auth.token }}"
+      register: health_anomalies
+
+    - name: Show anomalies
+      ansible.builtin.debug:
+        var: health_anomalies
+
+    - name: Assert anomalies only
+      ansible.builtin.assert:
+        that:
+          - not health_anomalies.changed
+          - health_anomalies.anomalies is defined
+          - health_anomalies.errors is not defined
+          - health_anomalies.anomalies.count is defined
+
+    # ── Test: Collect errors only ───────────────────────────────────────────
+    - name: Collect build errors only
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        scope: errors
+        auth_token: "{{ auth.token }}"
+      register: health_errors
+
+    - name: Show build errors
+      ansible.builtin.debug:
+        var: health_errors
+
+    - name: Assert errors only
+      ansible.builtin.assert:
+        that:
+          - not health_errors.changed
+          - health_errors.errors is defined
+          - health_errors.anomalies is not defined
+
+    # ── Test: Filter anomalies by severity ──────────────────────────────────
+    - name: Collect critical anomalies
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        scope: anomalies
+        severity: critical
+        auth_token: "{{ auth.token }}"
+      register: health_critical
+
+    - name: Show critical anomalies
+      ansible.builtin.debug:
+        var: health_critical
+
+    - name: Assert critical filter works
+      ansible.builtin.assert:
+        that:
+          - not health_critical.changed
+          - health_critical.anomalies is defined
+          - health_critical.anomalies.count is defined
+
+    # ── Test: Filter anomalies by node ──────────────────────────────────────
+    - name: Collect anomalies for a node filter
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        scope: anomalies
+        node_filter: "nonexistent_node"
+        auth_token: "{{ auth.token }}"
+      register: health_node
+
+    - name: Assert node filter returns zero
+      ansible.builtin.assert:
+        that:
+          - not health_node.changed
+          - health_node.anomalies.count == 0
+
+    # ── Test: Blueprint name resolution ─────────────────────────────────────
+    - name: Collect health using blueprint label
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "{{ blueprint_name }}"
+        auth_token: "{{ auth.token }}"
+      register: health_by_name
+
+    - name: Assert name resolution works
+      ansible.builtin.assert:
+        that:
+          - not health_by_name.changed
+          - health_by_name.anomalies is defined
+          - health_by_name.errors is defined
+
+    # ── Cleanup ─────────────────────────────────────────────────────────────
+    - name: Delete test blueprint
+      juniper.apstra.blueprint:
+        id: "{{ bp.id }}"
+        state: absent
+        lock_state: "ignore"
+        auth_token: "{{ auth.token }}"

--- a/ansible_collections/juniper/apstra/tests/blueprint_health.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint_health.yml
@@ -131,6 +131,56 @@
           - not health_node.changed
           - health_node.anomalies.count == 0
 
+    # ── Test: Filter anomalies by node + anomaly type ──────────────────────
+    - name: Set a sample anomaly for combined filtering
+      ansible.builtin.set_fact:
+        combined_sample_anomaly: "{{ health_all.anomalies.items[0] }}"
+      when: health_all.anomalies.count | int > 0
+
+    - name: Build combined node and type filters from sample anomaly
+      ansible.builtin.set_fact:
+        combined_node_filter: >-
+          {{
+            combined_sample_anomaly.get('identity', {}).get('system_id')
+            or combined_sample_anomaly.get('identity', {}).get('hostname')
+            or combined_sample_anomaly.get('identity', {}).get('label')
+            or combined_sample_anomaly.get('node_id')
+            or combined_sample_anomaly.get('node_label')
+            or combined_sample_anomaly.get('node')
+            or ''
+          }}
+        combined_anomaly_type: >-
+          {{
+            combined_sample_anomaly.get('anomaly_type')
+            or combined_sample_anomaly.get('type')
+            or (combined_sample_anomaly.get('anomaly_types', []) | first | default(''))
+          }}
+      when: health_all.anomalies.count | int > 0
+
+    - name: Collect anomalies using both node_filter and anomaly_type
+      juniper.apstra.blueprint_health:
+        id:
+          blueprint: "{{ bp.id.blueprint }}"
+        scope: anomalies
+        node_filter: "{{ combined_node_filter }}"
+        anomaly_type: "{{ combined_anomaly_type }}"
+        auth_token: "{{ auth.token }}"
+      register: health_node_and_type
+      when:
+        - health_all.anomalies.count | int > 0
+        - combined_node_filter | length > 0
+        - combined_anomaly_type | length > 0
+
+    - name: Assert combined node and type filter works
+      ansible.builtin.assert:
+        that:
+          - not health_node_and_type.changed
+          - health_node_and_type.anomalies.count | int > 0
+      when:
+        - health_all.anomalies.count | int > 0
+        - combined_node_filter | length > 0
+        - combined_anomaly_type | length > 0
+
     # ── Test: Blueprint name resolution ─────────────────────────────────────
     - name: Collect health using blueprint label
       juniper.apstra.blueprint_health:


### PR DESCRIPTION
## Summary

Add new `blueprint_health` module that collects anomalies and build errors/warnings from an Apstra blueprint as structured data for monitoring, alerting, and reporting.

**Jira:** [BOT-369](https://juniper-cto.atlassian.net/browse/BOT-369)

## Changes

### New Module: `blueprint_health`

- **Anomalies** — Retrieved via `GET /api/blueprints/{id}/anomalies` with filtering support
- **Build Errors** — Retrieved via `GET /api/blueprints/{id}/errors` (reuses existing `get_blueprint_errors()` from `bp_dci.py`)

### Parameters

| Parameter | Type | Description |
|-----------|------|-------------|
| `id` | dict | Blueprint identifier (ID or label) |
| `scope` | str | `anomalies` / `errors` / `all` (default: `all`) |
| `severity` | str | Filter: `critical` / `warning` / `info` |
| `node_filter` | str | Filter by system/node name |
| `anomaly_type` | str | Filter by anomaly type |

### Output Structure

```yaml
anomalies:
  count: 5
  items:
    - type: "cabling"
      severity: "error"
      node: "leaf1"
      message: "..."
errors:
  errors_count: 2
  warnings_count: 1
```

## Files

- `plugins/modules/blueprint_health.py` — New module
- `tests/blueprint_health.yml` — Integration test playbook
- `docs/blueprint_health_module.rst` — RST documentation
- `Makefile` — Registered `test-blueprint_health` target

## Testing

All integration tests pass (22 tasks, 0 failures):

- Collect all health data (scope=all)
- Collect anomalies only
- Collect errors only
- Filter by severity
- Filter by node
- Blueprint name resolution (label → UUID)
- Cleanup

## Acceptance Criteria

- [x] User can collect all anomalies from a blueprint
- [x] User can collect all build errors and warnings
- [x] Filtering by severity, type, and node works
- [x] Output is structured and machine-parseable
- [x] Integration test playbook created