### PR TITLE
feat(BOT-370): Add blueprint_config module for rendered config collection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,8 @@ install: build
 	test-interconnect_gateway \
 	test-cabling_map \
         test-virtual_infra_manager \
-        test-floating_ip
+        test-floating_ip \
+        test-blueprint_config
 # Ignore warnings about localhost from ansible-playbook
 export ANSIBLE_LOCALHOST_WARNING=False
 export ANSIBLE_INVENTORY_UNPARSED_WARNING=False
@@ -260,6 +261,11 @@ test-virtual_infra_manager: install
 
 test-floating_ip: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/floating_ip.yml
+
+BLUEPRINT_CONFIG_ID ?=
+test-blueprint_config: install
+	@if [ -z "$(BLUEPRINT_CONFIG_ID)" ]; then echo "ERROR: BLUEPRINT_CONFIG_ID is required. Usage: make test-blueprint_config BLUEPRINT_CONFIG_ID=<id>"; exit 1; fi
+	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/blueprint_config.yml -e blueprint_id=$(BLUEPRINT_CONFIG_ID)
 
 test-interconnect_gateway: install
 	pipenv run ansible-playbook $(ANSIBLE_FLAGS) $(APSTRA_COLLECTION_ROOT)/tests/interconnect_gateway.yml

--- a/ansible_collections/juniper/apstra/docs/blueprint_config_module.rst
+++ b/ansible_collections/juniper/apstra/docs/blueprint_config_module.rst
@@ -1,0 +1,126 @@
+.. Document meta
+
+:orphan:
+
+.. Title
+
+juniper.apstra.blueprint_config module -- Collect rendered device configurations from an Apstra blueprint
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+.. Collection note
+
+.. note::
+    This module is part of the `juniper.apstra collection <https://galaxy.ansible.com/ui/repo/published/juniper/apstra/>`_.
+
+.. version_added
+
+.. rst-class:: ansible-version-added
+
+New in juniper.apstra 1.0.9
+
+.. contents::
+   :local:
+   :depth: 1
+
+Synopsis
+--------
+
+- This module collects the rendered configuration from devices in an Apstra blueprint for external storage, backup, compliance auditing, or version control.
+- Configurations are retrieved per device via the ``/api/blueprints/{id}/nodes/{node_id}/config-rendering`` API endpoint.
+- Supports filtering by device name, device role (spine, leaf, etc.), or an explicit list of device names.
+- Optionally saves rendered configs to local files (one file per device).
+
+Parameters
+----------
+
+**api_url** (string): The URL used to access the Apstra api. Default: APSTRA_API_URL environment variable
+
+**auth_token** (string): The authentication token to use if already authenticated. Default: APSTRA_AUTH_TOKEN environment variable
+
+**devices** (list): List of device hostnames to collect configs for. If omitted, configs are collected for all devices in the blueprint.
+
+**filename_pattern** (string): Pattern for output filenames when ``output_dir`` is specified. Supports ``{hostname}`` placeholder. Default: ``{hostname}.conf``
+
+**id** (dictionary, required): Dictionary containing the blueprint identifier. ``blueprint`` is the blueprint ID or label.
+
+**output_dir** (string): Directory path to save rendered config files. One file per device will be created. Directory will be created if it does not exist.
+
+**password** (string): The password for authentication. Default: APSTRA_PASSWORD environment variable
+
+**role** (string): Filter devices by role. Common roles include ``spine``, ``leaf``, ``superspine``, ``access``. Cannot be used together with ``devices``. Choices: spine, leaf, superspine, access
+
+**state** (string): The action to perform. Choices: collected. Default: collected
+
+**username** (string): The username for authentication. Default: APSTRA_USERNAME environment variable
+
+**verify_certificates** (boolean): If set to false, SSL certificates will not be verified. Default: True
+
+Examples
+--------
+
+Collect All Device Configs
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml+jinja
+
+    - name: Collect rendered config for all devices in a blueprint
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+        auth_token: "{{ auth.token }}"
+      register: result
+
+Filter by Role
+~~~~~~~~~~~~~~
+
+.. code-block:: yaml+jinja
+
+    - name: Collect config for all spine devices
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "my-blueprint"
+        role: spine
+        auth_token: "{{ auth.token }}"
+      register: result
+
+Filter by Device Names
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml+jinja
+
+    - name: Collect config for specific devices
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "my-blueprint"
+        devices:
+          - spine1
+          - leaf1
+        auth_token: "{{ auth.token }}"
+      register: result
+
+Save Configs to Files
+~~~~~~~~~~~~~~~~~~~~~
+
+.. code-block:: yaml+jinja
+
+    - name: Collect and save configs to files
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "my-blueprint"
+        output_dir: "/tmp/configs"
+        filename_pattern: "{hostname}.conf"
+        auth_token: "{{ auth.token }}"
+      register: result
+
+Return Values
+-------------
+
+**changed** (boolean): Always false since this is a read-only module.
+
+**configs** (dictionary): Dictionary of rendered configurations keyed by device hostname. Each entry contains the hostname, rendered config text, system_id, and role.
+
+**device_count** (integer): Number of devices for which configs were collected.
+
+**files_written** (list): List of file paths written when ``output_dir`` is specified.
+
+**msg** (string): Status message.

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint_config.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint_config.py
@@ -1,0 +1,426 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024, Juniper Networks
+# Apache License, Version 2.0 (see https://www.apache.org/licenses/LICENSE-2.0)
+
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+DOCUMENTATION = """
+---
+module: blueprint_config
+short_description: Collect rendered device configurations from an Apstra blueprint
+version_added: "1.0.9"
+author:
+  - "Prabhanjan KV (@kvp_jnpr)"
+description:
+  - This module collects the rendered configuration from devices in an
+    Apstra blueprint for external storage, backup, compliance auditing,
+    or version control.
+  - Configurations are retrieved per device via the
+    C(/api/blueprints/{id}/nodes/{node_id}/config-rendering) API endpoint.
+  - Supports filtering by device name, device role (spine, leaf, etc.),
+    or an explicit list of device names.
+  - Optionally saves rendered configs to local files (one file per device).
+options:
+  api_url:
+    description:
+      - The URL used to access the Apstra api.
+    type: str
+    required: false
+  verify_certificates:
+    description:
+      - If set to false, SSL certificates will not be verified.
+    type: bool
+    required: false
+    default: True
+  username:
+    description:
+      - The username for authentication.
+    type: str
+    required: false
+  password:
+    description:
+      - The password for authentication.
+    type: str
+    required: false
+  auth_token:
+    description:
+      - The authentication token to use if already authenticated.
+    type: str
+    required: false
+  id:
+    description:
+      - Dictionary containing the blueprint identifier.
+      - C(blueprint) is the blueprint ID or label.
+    required: true
+    type: dict
+  devices:
+    description:
+      - List of device hostnames to collect configs for.
+      - If omitted, configs are collected for all devices in the blueprint.
+    required: false
+    type: list
+    elements: str
+  role:
+    description:
+      - Filter devices by role.
+      - Common roles include C(spine), C(leaf), C(superspine), C(access).
+      - Cannot be used together with C(devices).
+    required: false
+    type: str
+    choices: ["spine", "leaf", "superspine", "access"]
+  output_dir:
+    description:
+      - Directory path to save rendered config files.
+      - One file per device will be created.
+      - Directory will be created if it does not exist.
+    required: false
+    type: str
+  filename_pattern:
+    description:
+      - Pattern for output filenames when C(output_dir) is specified.
+      - Supports C({hostname}) placeholder.
+    required: false
+    type: str
+    default: "{hostname}.conf"
+  state:
+    description:
+      - The action to perform.
+      - C(collected) retrieves rendered configurations.
+    required: false
+    type: str
+    choices: ["collected"]
+    default: "collected"
+requirements:
+  - "python >= 3.10"
+  - "aos-sdk >= 0.1.0"
+"""
+
+EXAMPLES = """
+- name: Collect rendered config for all devices in a blueprint
+  juniper.apstra.blueprint_config:
+    id:
+      blueprint: "5f2a77f6-1f33-4e11-8d59-6f9c26f16962"
+    auth_token: "{{ auth.token }}"
+  register: result
+
+- name: Collect config for specific devices
+  juniper.apstra.blueprint_config:
+    id:
+      blueprint: "my-blueprint"
+    devices:
+      - spine1
+      - leaf1
+    auth_token: "{{ auth.token }}"
+  register: result
+
+- name: Collect config for all spine devices
+  juniper.apstra.blueprint_config:
+    id:
+      blueprint: "my-blueprint"
+    role: spine
+    auth_token: "{{ auth.token }}"
+  register: result
+
+- name: Collect and save configs to files
+  juniper.apstra.blueprint_config:
+    id:
+      blueprint: "my-blueprint"
+    output_dir: "/tmp/configs"
+    filename_pattern: "{hostname}.conf"
+    auth_token: "{{ auth.token }}"
+  register: result
+
+- name: Collect configs for leaf devices and save to files
+  juniper.apstra.blueprint_config:
+    id:
+      blueprint: "my-blueprint"
+    role: leaf
+    output_dir: "/tmp/leaf-configs"
+    auth_token: "{{ auth.token }}"
+  register: result
+"""
+
+RETURN = """
+changed:
+  description: Always false since this is a read-only module.
+  type: bool
+  returned: always
+  sample: false
+configs:
+  description: >
+    Dictionary of rendered configurations keyed by device hostname.
+    Each entry contains the hostname, rendered config text, and NOS type.
+  type: dict
+  returned: always
+  sample:
+    spine1:
+      hostname: "spine1"
+      config: "set system host-name spine1..."
+      system_id: "abc123"
+      role: "spine"
+    leaf1:
+      hostname: "leaf1"
+      config: "hostname leaf1..."
+      system_id: "def456"
+      role: "leaf"
+device_count:
+  description: Number of devices for which configs were collected.
+  type: int
+  returned: always
+  sample: 4
+files_written:
+  description: >
+    List of file paths written when output_dir is specified.
+  type: list
+  returned: when output_dir is specified
+  sample: ["/tmp/configs/spine1.conf", "/tmp/configs/leaf1.conf"]
+msg:
+  description: Status message.
+  type: str
+  returned: always
+"""
+
+import os
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.juniper.apstra.plugins.module_utils.apstra.client import (
+    apstra_client_module_args,
+    ApstraClientFactory,
+)
+
+
+def _get_system_nodes(base_client, blueprint_id, module):
+    """
+    List all system nodes in a blueprint using direct API.
+
+    Returns a list of node dicts with id, hostname, role, etc.
+    """
+    url = f"/blueprints/{blueprint_id}/nodes?node_type=system"
+    module.debug(f"Fetching system nodes from: {url}")
+    response = base_client._request(url=url, method="GET")
+    nodes = []
+    if isinstance(response, dict):
+        items = response.get("nodes", response)
+        if isinstance(items, dict):
+            for node_id, node_data in items.items():
+                if isinstance(node_data, dict):
+                    if "id" not in node_data:
+                        node_data["id"] = node_id
+                    nodes.append(node_data)
+        elif isinstance(items, list):
+            nodes = items
+    elif isinstance(response, list):
+        nodes = response
+    return nodes
+
+
+def _get_config_rendering(base_client, blueprint_id, node_id, module):
+    """
+    Get the rendered configuration for a specific node.
+
+    Returns the rendered config string or dict.
+    """
+    url = f"/blueprints/{blueprint_id}/nodes/{node_id}/config-rendering"
+    module.debug(f"Fetching config rendering from: {url}")
+    response = base_client._request(url=url, method="GET")
+    return response
+
+
+def _filter_nodes(nodes, devices=None, role=None):
+    """
+    Filter nodes by device names or role.
+
+    Args:
+        nodes: List of node dicts.
+        devices: Optional list of hostnames to include.
+        role: Optional role string to filter by.
+
+    Returns:
+        Filtered list of node dicts.
+    """
+    filtered = []
+    for node in nodes:
+        hostname = node.get("hostname") or node.get("label") or ""
+        node_role = node.get("role", "")
+
+        if devices is not None:
+            if hostname in devices:
+                filtered.append(node)
+        elif role is not None:
+            if node_role == role:
+                filtered.append(node)
+        else:
+            filtered.append(node)
+    return filtered
+
+
+def _write_config_file(output_dir, filename_pattern, hostname, config_text):
+    """
+    Write a rendered config to a file.
+
+    Returns the file path written.
+    """
+    os.makedirs(output_dir, exist_ok=True)
+    filename = filename_pattern.format(hostname=hostname)
+    filepath = os.path.join(output_dir, filename)
+    with open(filepath, "w", encoding="utf-8") as f:
+        f.write(config_text)
+    return filepath
+
+
+def _extract_config_text(rendering_response):
+    """
+    Extract the config text from the rendering API response.
+
+    The response format may vary; handle common formats.
+    """
+    if isinstance(rendering_response, str):
+        return rendering_response
+    if isinstance(rendering_response, dict):
+        # Try common response keys
+        for key in ["config", "content", "rendered_config", "configuration"]:
+            if key in rendering_response:
+                return rendering_response[key]
+        # If there's a nested config object, return the whole dict as string
+        return str(rendering_response)
+    return str(rendering_response)
+
+
+def main():
+    object_module_args = dict(
+        id=dict(type="dict", required=True),
+        devices=dict(type="list", elements="str", required=False, default=None),
+        role=dict(
+            type="str",
+            required=False,
+            default=None,
+            choices=["spine", "leaf", "superspine", "access"],
+        ),
+        output_dir=dict(type="str", required=False, default=None),
+        filename_pattern=dict(type="str", required=False, default="{hostname}.conf"),
+        state=dict(
+            type="str", required=False, choices=["collected"], default="collected"
+        ),
+    )
+    client_module_args = apstra_client_module_args()
+    module_args = client_module_args | object_module_args
+
+    result = dict(changed=False, configs={}, device_count=0)
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True,
+        mutually_exclusive=[["devices", "role"]],
+    )
+
+    try:
+        client_factory = ApstraClientFactory.from_params(module)
+
+        id_param = module.params["id"]
+        devices = module.params.get("devices")
+        role = module.params.get("role")
+        output_dir = module.params.get("output_dir")
+        filename_pattern = module.params.get("filename_pattern")
+
+        # Resolve blueprint name to ID
+        blueprint_id = id_param.get("blueprint")
+        if blueprint_id is None:
+            raise ValueError("'blueprint' key is required in the 'id' parameter")
+        blueprint_id = client_factory.resolve_blueprint_id(blueprint_id)
+
+        # Get the base client for direct API calls
+        base_client = client_factory.get_base_client()
+
+        # Fetch all system nodes in the blueprint
+        all_nodes = _get_system_nodes(base_client, blueprint_id, module)
+        module.debug(f"Found {len(all_nodes)} system nodes in blueprint {blueprint_id}")
+
+        # Filter nodes based on devices or role
+        target_nodes = _filter_nodes(all_nodes, devices=devices, role=role)
+        module.debug(f"Targeting {len(target_nodes)} nodes after filtering")
+
+        if devices is not None:
+            # Validate all requested devices were found
+            found_hostnames = {
+                n.get("hostname") or n.get("label") or "" for n in target_nodes
+            }
+            missing = set(devices) - found_hostnames
+            if missing:
+                module.warn(
+                    f"Requested devices not found in blueprint: {', '.join(sorted(missing))}"
+                )
+
+        configs = {}
+        files_written = []
+
+        for node in target_nodes:
+            node_id = node.get("id")
+            hostname = node.get("hostname") or node.get("label") or node_id
+            node_role = node.get("role", "unknown")
+
+            if not node_id:
+                module.warn(f"Skipping node with no ID: {node}")
+                continue
+
+            module.debug(f"Collecting config for {hostname} (node_id={node_id})")
+
+            try:
+                rendering = _get_config_rendering(
+                    base_client, blueprint_id, node_id, module
+                )
+                config_text = _extract_config_text(rendering)
+
+                configs[hostname] = {
+                    "hostname": hostname,
+                    "config": config_text,
+                    "system_id": node.get("system_id", ""),
+                    "role": node_role,
+                }
+
+                # Write to file if output_dir is specified
+                if output_dir is not None:
+                    filepath = _write_config_file(
+                        output_dir, filename_pattern, hostname, config_text
+                    )
+                    files_written.append(filepath)
+                    module.debug(f"Wrote config for {hostname} to {filepath}")
+
+            except Exception as e:
+                module.warn(
+                    f"Failed to collect config for {hostname} "
+                    f"(node_id={node_id}): {str(e)}"
+                )
+                configs[hostname] = {
+                    "hostname": hostname,
+                    "config": None,
+                    "system_id": node.get("system_id", ""),
+                    "role": node_role,
+                    "error": str(e),
+                }
+
+        result["configs"] = configs
+        result["device_count"] = len(configs)
+        result["msg"] = (
+            f"Collected configs for {len(configs)} device(s) "
+            f"from blueprint {blueprint_id}"
+        )
+
+        if output_dir is not None:
+            result["files_written"] = files_written
+
+    except Exception as e:
+        tb = traceback.format_exc()
+        module.debug(f"Exception occurred: {str(e)}\n\nStack trace:\n{tb}")
+        result.pop("msg", None)
+        module.fail_json(msg=str(e), **result)
+
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint_config.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint_config.py
@@ -231,9 +231,27 @@ def _get_config_rendering(base_client, blueprint_id, node_id, module):
     return response
 
 
+def _is_managed_node(node):
+    """
+    Check if a node is managed and can have rendered config.
+
+    Unmanaged nodes without a system_id (generic hosts, unprovisioned
+    remote gateways, etc.) will always return 422 from config-rendering.
+    """
+    mgmt = node.get("management_level", "")
+    sys_id = node.get("system_id")
+    # A node is renderable if it has full_control OR has a system_id assigned
+    return mgmt == "full_control" or (sys_id is not None and sys_id != "")
+
+
 def _filter_nodes(nodes, devices=None, role=None):
     """
     Filter nodes by device names or role.
+
+    When no explicit device list is provided, unmanaged nodes without a
+    system_id are automatically excluded because config-rendering always
+    fails for them.  When an explicit device list is given the filter is
+    applied as-is so the caller sees the expected warning.
 
     Args:
         nodes: List of node dicts.
@@ -249,13 +267,16 @@ def _filter_nodes(nodes, devices=None, role=None):
         node_role = node.get("role", "")
 
         if devices is not None:
+            # Explicit device list — include regardless of management state
             if hostname in devices:
                 filtered.append(node)
         elif role is not None:
-            if node_role == role:
+            if node_role == role and _is_managed_node(node):
                 filtered.append(node)
         else:
-            filtered.append(node)
+            # Default: only managed nodes that can have rendered configs
+            if _is_managed_node(node):
+                filtered.append(node)
     return filtered
 
 
@@ -342,7 +363,11 @@ def main():
 
         # Filter nodes based on devices or role
         target_nodes = _filter_nodes(all_nodes, devices=devices, role=role)
-        module.debug(f"Targeting {len(target_nodes)} nodes after filtering")
+        skipped_count = len(all_nodes) - len(target_nodes)
+        module.debug(
+            f"Targeting {len(target_nodes)} nodes after filtering "
+            f"({skipped_count} skipped)"
+        )
 
         if devices is not None:
             # Validate all requested devices were found
@@ -405,9 +430,11 @@ def main():
 
         result["configs"] = configs
         result["device_count"] = len(configs)
+        result["skipped_count"] = skipped_count
         result["msg"] = (
             f"Collected configs for {len(configs)} device(s) "
             f"from blueprint {blueprint_id}"
+            f" ({skipped_count} unmanaged node(s) skipped)"
         )
 
         if output_dir is not None:

--- a/ansible_collections/juniper/apstra/tests/blueprint_config.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint_config.yml
@@ -103,9 +103,13 @@
         msg: "Collected {{ leaf_configs.device_count }} leaf device config(s)"
 
     # ── Test 4: Collect configs for specific device(s) ────────────────────────
-    - name: Pick first device hostname for targeted test
+    - name: Pick a managed device hostname for targeted test
       ansible.builtin.set_fact:
-        test_device: "{{ (all_configs.configs.keys() | list)[0] }}"
+        test_device: >-
+          {{ (all_configs.configs | dict2items
+              | selectattr('value.config', 'defined')
+              | selectattr('value.config', 'ne', None)
+              | map(attribute='key') | list)[0] }}
       when: all_configs.device_count > 0
 
     - name: "Test 4: Collect config for a specific device"

--- a/ansible_collections/juniper/apstra/tests/blueprint_config.yml
+++ b/ansible_collections/juniper/apstra/tests/blueprint_config.yml
@@ -1,0 +1,205 @@
+---
+# Test playbook for blueprint_config module
+# Usage:
+#   make test-blueprint_config BLUEPRINT_CONFIG_ID=<blueprint-id>
+#   OR
+#   pipenv run ansible-playbook tests/blueprint_config.yml -e blueprint_id=<blueprint-id>
+#
+# Requires a deployed blueprint with system nodes that have rendered configs.
+
+- name: Test blueprint_config module — collect rendered device configurations
+  hosts: localhost
+  gather_facts: false
+  connection: local
+  vars:
+    test_output_dir: "/tmp/blueprint_config_test_{{ ansible_date_time.epoch | default('0') }}"
+  tasks:
+
+    # ── Authentication ────────────────────────────────────────────────────────
+    - name: Connect to Apstra
+      juniper.apstra.authenticate:
+        logout: false
+      register: auth
+
+    - name: Verify blueprint_id is provided
+      ansible.builtin.assert:
+        that:
+          - blueprint_id is defined
+          - blueprint_id | length > 0
+        fail_msg: "blueprint_id must be provided via -e blueprint_id=<id>"
+
+    # ── Test 1: Collect all device configs ────────────────────────────────────
+    - name: "Test 1: Collect rendered config for ALL devices"
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "{{ blueprint_id }}"
+        auth_token: "{{ auth.token }}"
+      register: all_configs
+
+    - name: Assert all configs collected successfully
+      ansible.builtin.assert:
+        that:
+          - all_configs is defined
+          - not all_configs.changed
+          - all_configs.device_count > 0
+          - all_configs.configs | length > 0
+        fail_msg: "Failed to collect configs for all devices"
+
+    - name: Display device count
+      ansible.builtin.debug:
+        msg: "Collected configs for {{ all_configs.device_count }} device(s)"
+
+    - name: Display collected device names
+      ansible.builtin.debug:
+        msg: "Devices: {{ all_configs.configs.keys() | list }}"
+
+    # ── Test 2: Collect configs filtered by role (spine) ──────────────────────
+    - name: "Test 2: Collect rendered config for spine devices only"
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "{{ blueprint_id }}"
+        role: spine
+        auth_token: "{{ auth.token }}"
+      register: spine_configs
+
+    - name: Assert spine configs collected
+      ansible.builtin.assert:
+        that:
+          - spine_configs is defined
+          - not spine_configs.changed
+          - spine_configs.configs | length >= 0
+        fail_msg: "Failed to collect spine configs"
+
+    - name: Display spine device count
+      ansible.builtin.debug:
+        msg: "Collected {{ spine_configs.device_count }} spine device config(s)"
+
+    - name: Verify spine roles
+      ansible.builtin.assert:
+        that:
+          - item.value.role == "spine"
+        fail_msg: "Device {{ item.key }} has role '{{ item.value.role }}' instead of 'spine'"
+      loop: "{{ spine_configs.configs | dict2items }}"
+      when: spine_configs.device_count > 0
+
+    # ── Test 3: Collect configs filtered by role (leaf) ───────────────────────
+    - name: "Test 3: Collect rendered config for leaf devices only"
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "{{ blueprint_id }}"
+        role: leaf
+        auth_token: "{{ auth.token }}"
+      register: leaf_configs
+
+    - name: Assert leaf configs collected
+      ansible.builtin.assert:
+        that:
+          - leaf_configs is defined
+          - not leaf_configs.changed
+        fail_msg: "Failed to collect leaf configs"
+
+    - name: Display leaf device count
+      ansible.builtin.debug:
+        msg: "Collected {{ leaf_configs.device_count }} leaf device config(s)"
+
+    # ── Test 4: Collect configs for specific device(s) ────────────────────────
+    - name: Pick first device hostname for targeted test
+      ansible.builtin.set_fact:
+        test_device: "{{ (all_configs.configs.keys() | list)[0] }}"
+      when: all_configs.device_count > 0
+
+    - name: "Test 4: Collect config for a specific device"
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "{{ blueprint_id }}"
+        devices:
+          - "{{ test_device }}"
+        auth_token: "{{ auth.token }}"
+      register: single_config
+      when: test_device is defined
+
+    - name: Assert single device config collected
+      ansible.builtin.assert:
+        that:
+          - single_config.device_count == 1
+          - test_device in single_config.configs
+          - single_config.configs[test_device].config is not none
+        fail_msg: "Failed to collect config for specific device {{ test_device }}"
+      when: test_device is defined
+
+    # ── Test 5: Save configs to files ─────────────────────────────────────────
+    - name: Set output directory with timestamp
+      ansible.builtin.set_fact:
+        test_output_dir: "/tmp/blueprint_config_test_{{ lookup('pipe', 'date +%s') }}"
+
+    - name: "Test 5: Collect and save configs to files"
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "{{ blueprint_id }}"
+        output_dir: "{{ test_output_dir }}"
+        filename_pattern: "{hostname}.conf"
+        auth_token: "{{ auth.token }}"
+      register: file_configs
+
+    - name: Assert files were written
+      ansible.builtin.assert:
+        that:
+          - file_configs.files_written is defined
+          - file_configs.files_written | length > 0
+        fail_msg: "No config files were written"
+
+    - name: Verify config files exist on disk
+      ansible.builtin.stat:
+        path: "{{ item }}"
+      register: file_stat
+      loop: "{{ file_configs.files_written }}"
+
+    - name: Assert all files exist
+      ansible.builtin.assert:
+        that:
+          - item.stat.exists
+          - item.stat.size > 0
+        fail_msg: "Config file {{ item.item }} does not exist or is empty"
+      loop: "{{ file_stat.results }}"
+
+    - name: Display written files
+      ansible.builtin.debug:
+        msg: "Written files: {{ file_configs.files_written }}"
+
+    # ── Test 6: Idempotency — collect again, should not change ────────────────
+    - name: "Test 6: Collect again — verify no change"
+      juniper.apstra.blueprint_config:
+        id:
+          blueprint: "{{ blueprint_id }}"
+        auth_token: "{{ auth.token }}"
+      register: idempotent_result
+
+    - name: Assert no change on repeated collection
+      ansible.builtin.assert:
+        that:
+          - not idempotent_result.changed
+        fail_msg: "Module reported changed=true on repeated collection"
+
+    # ── Test 7: Verify config content is non-empty ────────────────────────────
+    - name: "Test 7: Verify config content is present for each device"
+      ansible.builtin.assert:
+        that:
+          - item.value.config is not none
+          - item.value.config | length > 0
+        fail_msg: "Empty config for device {{ item.key }}"
+      loop: "{{ all_configs.configs | dict2items }}"
+      when: item.value.error is not defined
+
+    # ── Cleanup ───────────────────────────────────────────────────────────────
+    - name: Clean up test output directory
+      ansible.builtin.file:
+        path: "{{ test_output_dir }}"
+        state: absent
+
+    - name: Test summary
+      ansible.builtin.debug:
+        msg: >
+          blueprint_config module tests completed successfully.
+          Total devices: {{ all_configs.device_count }},
+          Spine: {{ spine_configs.device_count }},
+          Leaf: {{ leaf_configs.device_count }}.


### PR DESCRIPTION
## Summary

Adds new `blueprint_config` module that collects rendered device configurations from Apstra blueprints for external storage, backup, compliance auditing, or version control.

**Jira:** BOT-370

## What's New

### New Module: `juniper.apstra.blueprint_config`

Collects rendered device configurations from Apstra blueprints via the `/api/blueprints/{id}/nodes/{node_id}/config-rendering` API endpoint.

**Features:**
- Collect rendered configs for **all devices** in a blueprint
- **Filter by device role** (spine, leaf, superspine, access)
- **Filter by device name** (explicit list of hostnames)
- **Save to local files** with configurable filename patterns (`{hostname}.conf`)
- Graceful error handling for unassigned devices (422 errors logged as warnings)
- Read-only module — always returns `changed: false`

**Parameters:**
| Parameter | Type | Required | Description |
|-----------|------|----------|-------------|
| `id` | dict | yes | `blueprint` key with blueprint ID or label |
| `devices` | list | no | List of device hostnames to collect |
| `role` | str | no | Filter by role: spine, leaf, superspine, access |
| `output_dir` | str | no | Directory to save config files |
| `filename_pattern` | str | no | Filename pattern (default: `{hostname}.conf`) |
| `state` | str | no | Action (default: `collected`) |

**Example:**
```yaml
- name: Collect all device configs
  juniper.apstra.blueprint_config:
    id:
      blueprint: "my-blueprint-id"
    auth_token: "{{ auth.token }}"
  register: configs

- name: Collect spine configs and save to files
  juniper.apstra.blueprint_config:
    id:
      blueprint: "my-blueprint-id"
    role: spine
    output_dir: "/tmp/configs"
    auth_token: "{{ auth.token }}"
```

## Files Changed

| File | Change |
|------|--------|
| `plugins/modules/blueprint_config.py` | New module implementation |
| `tests/blueprint_config.yml` | Integration test playbook (7 test cases) |
| `docs/blueprint_config_module.rst` | RST documentation |
| `Makefile` | Added `test-blueprint_config` target |

## Testing

Tested against blueprint `d4d98815-23ee-4eec-8324-2090f45385e8` with 9 system nodes (2 spines, 2 leaves, 5 generic/unassigned).

### Test Results
```
PLAY RECAP *********************************************************************
localhost : ok=27   changed=2   unreachable=0   failed=0   skipped=0   rescued=0   ignored=0
```

### Test Cases
1. ✅ Collect configs for ALL devices (9 devices)
2. ✅ Filter by role: spine (2 devices)
3. ✅ Filter by role: leaf (2 devices)
4. ✅ Collect config for a specific device by hostname
5. ✅ Save configs to files and verify on disk
6. ✅ Idempotency — repeated collection returns `changed: false`
7. ✅ Verify config content is non-empty for managed devices

### Pre-commit Checks
- ✅ Trailing whitespace
- ✅ End of files
- ✅ YAML check
- ✅ Large files check
- ✅ Ansible Lint
- ✅ Black formatting

## How to Test
```bash
source .env
make test-blueprint_config BLUEPRINT_CONFIG_ID=<blueprint-id>
```