### PR TITLE
blueprint/security_zone: dump version to 1.1.0 because can't add feat…

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -23,7 +23,7 @@ description:
   - The QE query and node utilities are also available as importable
     helpers in C(module_utils/apstra/bp_query.py) and
     C(module_utils/apstra/bp_nodes.py) for use by other modules.
-version_added: "1.0.9"
+version_added: "1.1.0"
 author:
   - "Edwin Jacques (@edwinpjacques)"
   - "Vamsi Gavini (@vgavini)"

--- a/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/security_zone.py
@@ -14,7 +14,7 @@ module: security_zone
 
 short_description: Manage security zones (tenants/VRFs) and tenants in Apstra
 
-version_added: "1.0.9"
+version_added: "1.1.0"
 
 author:
   - "Edwin Jacques (@edwinpjacques)"


### PR DESCRIPTION
…ure on minor release

version-added-must-be-major-or-minor: DOCUMENTATION: version_added ('1.0.9') must be a major or minor release, not a patch release (see specification at https://semver.org/).

also blueprint.py and security_zone.py already exist...

reverse to previous value (0.1.0) ?