### PR TITLE
blueprint[config|health]: add to ignore and bump version_added to 1.1.0

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint_config.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint_config.py
@@ -12,7 +12,7 @@ DOCUMENTATION = """
 ---
 module: blueprint_config
 short_description: Collect rendered device configurations from an Apstra blueprint
-version_added: "1.0.9"
+version_added: "1.1.0"
 author:
   - "Prabhanjan KV (@kvp_jnpr)"
 description:

--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint_health.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint_health.py
@@ -12,7 +12,7 @@ DOCUMENTATION = """
 ---
 module: blueprint_health
 short_description: Collect anomalies and build errors from an Apstra blueprint
-version_added: "1.0.9"
+version_added: "1.1.0"
 author:
   - "Prabhanjan KV (@kvp_jnpr)"
 description:

--- a/ansible_collections/juniper/apstra/tests/sanity/ignore-2.16.txt
+++ b/ansible_collections/juniper/apstra/tests/sanity/ignore-2.16.txt
@@ -1,6 +1,8 @@
 plugins/modules/apstra_facts.py validate-modules:missing-gplv3-license
 plugins/modules/authenticate.py validate-modules:missing-gplv3-license
 plugins/modules/blueprint.py validate-modules:missing-gplv3-license
+plugins/modules/blueprint_config.py validate-modules:missing-gplv3-license
+plugins/modules/blueprint_health.py validate-modules:missing-gplv3-license
 plugins/modules/cabling_map.py validate-modules:missing-gplv3-license
 plugins/modules/configlets.py validate-modules:missing-gplv3-license
 plugins/modules/connectivity_template.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
missing-gplv3-license: GPLv3 license header not found in the first 20 lines of the module
ersion-added-must-be-major-or-minor: DOCUMENTATION: version_added ('1.0.9') must be a major or minor release, not a patch release (see specification at https://semver.org/).