### PR TITLE
blueprint: rack_count (on ansible) is None

### DIFF
--- a/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
+++ b/ansible_collections/juniper/apstra/plugins/modules/blueprint.py
@@ -102,7 +102,6 @@ options:
       - Only used when C(state=rack_added).
     type: int
     required: false
-    default: 1
   racks_to_add:
     description:
       - Number of racks to add in this run.


### PR DESCRIPTION
but after on the code it is set to 1 if no rack_count or rack_to_add set